### PR TITLE
chore: adiciona configuração necessaria para hospedar na gcp

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.env*
+.git
+*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Stage 1: build
+FROM node:22-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+ 
+ARG VITE_API_URL
+ARG VITE_SOCKET_URL
+ENV VITE_API_URL=$VITE_API_URL
+ENV VITE_SOCKET_URL=$VITE_SOCKET_URL
+ 
+RUN npm run build
+ 
+# Stage 2: serve
+FROM nginx:alpine
+COPY --from=builder /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 8080
+CMD ["nginx", "-g", "daemon off;"]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,44 @@
+steps:
+  # Build da imagem Docker
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - build
+      - '--build-arg'
+      - 'VITE_API_URL=$_VITE_API_URL'
+      - '--build-arg'
+      - 'VITE_SOCKET_URL=$_VITE_SOCKET_URL'
+      - '-t'
+      - '$_REGION-docker.pkg.dev/$PROJECT_ID/$_REPO/$_SERVICE_NAME:$COMMIT_SHA'
+      - '-t'
+      - '$_REGION-docker.pkg.dev/$PROJECT_ID/$_REPO/$_SERVICE_NAME:latest'
+      - '.'
+ 
+  # Push para Artifact Registry
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - push
+      - '--all-tags'
+      - '$_REGION-docker.pkg.dev/$PROJECT_ID/$_REPO/$_SERVICE_NAME'
+ 
+  # Deploy no Cloud Run
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: gcloud
+    args:
+      - run
+      - deploy
+      - '$_SERVICE_NAME'
+      - '--image=$_REGION-docker.pkg.dev/$PROJECT_ID/$_REPO/$_SERVICE_NAME:$COMMIT_SHA'
+      - '--region=$_REGION'
+      - '--platform=managed'
+      - '--allow-unauthenticated'
+      - '--port=8080'
+ 
+substitutions:
+  _REGION: southamerica-east1
+  _REPO: frontend
+  _SERVICE_NAME: frontend
+  _VITE_API_URL: ''
+  _VITE_SOCKET_URL: ''
+ 
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,17 @@
+server {
+    listen 8080;
+    root /usr/share/nginx/html;
+    index index.html;
+ 
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml image/svg+xml;
+ 
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+ 
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff2)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+}


### PR DESCRIPTION
## Resumo 

Esta PR adiciona arquivos necessários para containerização do repositório front-end e automação do deploy usando Docker e a infraestrutura da Google Cloud Platform.

## Detalhamento
Alterações no repositório front-end:

- `Dockerfile` criado
- `nginx.conf` criado
- `cloudbuild.yaml` criado
- `.dockerignore` criado
- Todos os arquivos foram adicionados à raiz do repositório front-end
- Os códigos dos arquivos foram importados da Issue

## Impacto

- `Dockerfile` padroniza o ambiente da aplicação para build em 2 estágios (Node + Nginx)
- `nginx.conf` configura Nginx para servir arquivos estáticos à SPA, garantindo funcionamento do React Router e adicionando otimizações com gzip e cache de assets de 1 ano
- `cloudbuild.yaml` define a pipeline CI/CD no Google Cloud Build, automatizando:
  - build da imagem Docker
  - envio para Artifact Registry
  - deploy no Cloud Run
  - *usa variáveis de ambiente para url e websocket da aplicação
  - As variáveis VITE_* são injetadas em tempo de build, sendo **necessário novo build para refletir alterações**
 - `.dockerignore` reduz o tamanho e tempo da build ao excluir arquivos desnecessários

Não há impacto no fluxo de desenvolvimento local (`npm run dev`), apenas a introdução de um pipeline de build e deploy automatizado por ambiente.

Favor validar e fechar Issue @IgorLGomes 
