### PR TITLE
Chore/atualiza readme e cloudbuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Ele é responsável pela interface do usuário, incluindo a Landing Page públic
 
 | Branch    | URL       |
 | --------- | --------- |
-| `main`    | (definir) |
-| `develop` | (definir) |
+| `main`    | https://frontend-main-412027788376.southamerica-east1.run.app |
+| `develop` | https://frontend-dev-412027788376.southamerica-east1.run.app |
 
 ### API (Back-end)
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -8,37 +8,36 @@ steps:
       - '--build-arg'
       - 'VITE_SOCKET_URL=$_VITE_SOCKET_URL'
       - '-t'
-      - '$_REGION-docker.pkg.dev/$PROJECT_ID/$_REPO/$_SERVICE_NAME:$COMMIT_SHA'
+      - '$_REGION-docker.pkg.dev/$PROJECT_ID/$_REPO/frontend-$BRANCH_NAME:$COMMIT_SHA'
       - '-t'
-      - '$_REGION-docker.pkg.dev/$PROJECT_ID/$_REPO/$_SERVICE_NAME:latest'
+      - '$_REGION-docker.pkg.dev/$PROJECT_ID/$_REPO/frontend-$BRANCH_NAME:latest'
       - '.'
- 
+
   # Push para Artifact Registry
   - name: 'gcr.io/cloud-builders/docker'
     args:
       - push
       - '--all-tags'
-      - '$_REGION-docker.pkg.dev/$PROJECT_ID/$_REPO/$_SERVICE_NAME'
- 
-  # Deploy no Cloud Run
+      - '$_REGION-docker.pkg.dev/$PROJECT_ID/$_REPO/frontend-$BRANCH_NAME'
+
+  # Deploy no Cloud Run (serviço por branch)
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: gcloud
     args:
       - run
       - deploy
-      - '$_SERVICE_NAME'
-      - '--image=$_REGION-docker.pkg.dev/$PROJECT_ID/$_REPO/$_SERVICE_NAME:$COMMIT_SHA'
+      - 'frontend-$BRANCH_NAME'
+      - '--image=$_REGION-docker.pkg.dev/$PROJECT_ID/$_REPO/frontend-$BRANCH_NAME:$COMMIT_SHA'
       - '--region=$_REGION'
       - '--platform=managed'
       - '--allow-unauthenticated'
       - '--port=8080'
- 
+
 substitutions:
   _REGION: southamerica-east1
   _REPO: frontend
-  _SERVICE_NAME: frontend
   _VITE_API_URL: ''
   _VITE_SOCKET_URL: ''
- 
+
 options:
   logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
## Descrição

Este pull request atualiza o pipeline de deploy e a documentação para permitir deploys do frontend por branch, facilitando o gerenciamento de diferentes ambientes para cada branch.

As mudanças incluem:
- Atualização da tag das imagens Docker
- Nomeação dos serviços no Cloud Run
- Inclusão das URLs corretas para as branches `main` e `develop` na documentação

---

##  Melhorias no Pipeline de Deploy

- Atualização das etapas de build e push do Docker no `cloudbuild.yaml` para utilizar tags no formato `frontend-$BRANCH_NAME` em vez de um nome de serviço fixo, garantindo que cada branch tenha sua própria imagem e serviço.
- Alteração da etapa de deploy no Cloud Run para utilizar um serviço nomeado como `frontend-$BRANCH_NAME` por branch, em vez de um único serviço compartilhado.
- Remoção da substituição `_SERVICE_NAME` do `cloudbuild.yaml`, já que não é mais necessária com a adoção de nomes de serviço por branch.

---

##  Atualizações na Documentação

- Atualização do `README.md` com as URLs corretas de deploy para as branches `main` e `develop`, refletindo a nova estrutura de deploy por branch.