### PR TITLE
feat: Integra módulo de admin/usuarios com a API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+CLAUDE.md
+
+memory

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,7 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3275,6 +3276,7 @@
       "version": "24.12.0",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3283,6 +3285,7 @@
       "version": "19.2.14",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3291,6 +3294,7 @@
       "version": "19.2.3",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3334,6 +3338,7 @@
       "version": "8.57.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.1",
         "@typescript-eslint/types": "8.57.1",
@@ -3581,6 +3586,7 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3735,6 +3741,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3919,7 +3926,8 @@
     },
     "node_modules/embla-carousel": {
       "version": "8.6.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -4034,6 +4042,7 @@
       "version": "9.39.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4492,7 +4501,8 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -4932,6 +4942,7 @@
     "node_modules/picomatch": {
       "version": "4.0.3",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4956,6 +4967,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5000,6 +5012,7 @@
     "node_modules/react": {
       "version": "19.2.4",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5029,6 +5042,7 @@
     "node_modules/react-dom": {
       "version": "19.2.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5058,6 +5072,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.1.tgz",
       "integrity": "sha512-RhwBoy2ygeVZje+C+bwJ8g0NjTdBmDlJvAUHTxRjTmSUKPYsKfMphkS2sgEMotsY03bP358yEYlnUeZy//D9Ig==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -5368,7 +5383,8 @@
     },
     "node_modules/tailwindcss": {
       "version": "4.2.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -5434,6 +5450,7 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5552,6 +5569,7 @@
     "node_modules/vite": {
       "version": "7.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -5693,6 +5711,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/components/admin/usuarios/UserForm.tsx
+++ b/src/components/admin/usuarios/UserForm.tsx
@@ -37,10 +37,12 @@ const getSchema = (mode: "create" | "edit") =>
       confirmarSenha:
         mode === "create" ? z.string().min(1, "Confirme sua senha") : z.string(),
     })
-    .refine((data) => !data.senha || data.senha === data.confirmarSenha, {
-      message: "As senhas não coincidem",
-      path: ["confirmarSenha"],
-    });
+    .refine(
+      (data) =>
+        (!data.senha && !data.confirmarSenha) ||
+        (!!data.senha && data.senha === data.confirmarSenha),
+      { message: "As senhas não coincidem", path: ["confirmarSenha"] }
+    );
 
 type UserFormData = z.infer<ReturnType<typeof getSchema>>;
 

--- a/src/components/admin/usuarios/UserForm.tsx
+++ b/src/components/admin/usuarios/UserForm.tsx
@@ -17,22 +17,32 @@ import {
 } from "@/components/ui/select";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
-const userSchema = z
-  .object({
-    nome: z.string().min(1, "Nome é obrigatório"),
-    email: z.string().email("E-mail inválido"),
-    documento: z.string().min(1, "CPF/CNPJ é obrigatório"),
-    telefone: z.string().min(1, "Telefone é obrigatório"),
-    tipo: z.enum(["Administrador", "Cliente"]),
-    senha: z.string().min(6, "Senha deve ter pelo menos 6 caracteres"),
-    confirmarSenha: z.string().min(6, "Confirme sua senha"),
-  })
-  .refine((data) => data.senha === data.confirmarSenha, {
-    message: "As senhas não coincidem",
-    path: ["confirmarSenha"],
-  });
+const getSchema = (mode: "create" | "edit") =>
+  z
+    .object({
+      nome: z.string().min(1, "Nome é obrigatório"),
+      email: z.string().email("E-mail inválido"),
+      documento: z.string().min(1, "CPF/CNPJ é obrigatório"),
+      telefone: z.string().min(1, "Telefone é obrigatório"),
+      tipo: z.enum(["Administrador", "Cliente"]),
+      senha:
+        mode === "create"
+          ? z.string().min(6, "Senha deve ter pelo menos 6 caracteres")
+          : z
+              .string()
+              .refine(
+                (v) => v === "" || v.length >= 6,
+                "Senha deve ter pelo menos 6 caracteres"
+              ),
+      confirmarSenha:
+        mode === "create" ? z.string().min(1, "Confirme sua senha") : z.string(),
+    })
+    .refine((data) => !data.senha || data.senha === data.confirmarSenha, {
+      message: "As senhas não coincidem",
+      path: ["confirmarSenha"],
+    });
 
-type UserFormData = z.infer<typeof userSchema>;
+type UserFormData = z.infer<ReturnType<typeof getSchema>>;
 
 interface UserFormProps {
   mode: "create" | "edit";
@@ -40,6 +50,7 @@ interface UserFormProps {
   onSubmit: (data: UserFormData) => void;
   onCancel: () => void;
   onDelete?: () => void;
+  saving?: boolean;
 }
 
 export function UserForm({
@@ -48,6 +59,7 @@ export function UserForm({
   onSubmit,
   onCancel,
   onDelete,
+  saving = false,
 }: UserFormProps) {
   const [showSenha, setShowSenha] = useState(false);
   const [showConfirmar, setShowConfirmar] = useState(false);
@@ -61,7 +73,7 @@ export function UserForm({
     watch,
     formState: { errors },
   } = useForm<UserFormData>({
-    resolver: zodResolver(userSchema),
+    resolver: zodResolver(getSchema(mode)),
     defaultValues: {
       nome: initialData?.nome || "",
       email: initialData?.email || "",
@@ -240,9 +252,9 @@ export function UserForm({
           {isEdit ? "Cancelar alterações" : "Cancelar criação"}
         </Button>
 
-        <Button type="submit" className="bg-[#3b82f6] text-white hover:bg-[#2563eb]">
+        <Button type="submit" disabled={saving} className="bg-[#3b82f6] text-white hover:bg-[#2563eb]">
           <Save className="mr-2 h-4 w-4" />
-          {isEdit ? "Salvar usuário" : "Criar usuário"}
+          {saving ? "Salvando..." : isEdit ? "Salvar usuário" : "Criar usuário"}
         </Button>
       </div>
 

--- a/src/pages/admin/Usuarios.tsx
+++ b/src/pages/admin/Usuarios.tsx
@@ -1,5 +1,6 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { usuariosService } from '@/services/usuariosService';
 import {
   ArrowUpDown,
   SquarePen,
@@ -28,54 +29,34 @@ import { DatePicker } from '@/components/ui/DatePicker';
 import { ConfirmDeleteModal } from '@/components/ui/ConfirmDeleteModal';
 
 type User = {
-  id: string;
+  id: number;
   nome: string;
   email: string;
-  nivel: 'Administrador' | 'Cliente' | 'Nível 3';
+  nivel: string;
   dataCadastro: Date;
-};
-
-const generateMockUsers = (): User[] => {
-  const baseUsers = [
-    { id: '#001', nome: 'Amanda Costa', email: 'amanda.costa@gmail.com', nivel: 'Administrador' as const, dataCadastro: new Date(2026, 2, 8) },
-    { id: '#002', nome: 'Giovana Albanés', email: 'giovana.albanes@gmail.com', nivel: 'Cliente' as const, dataCadastro: new Date(2026, 2, 8) },
-    { id: '#003', nome: 'Igor Gomes', email: 'igor.gomes@gmail.com', nivel: 'Cliente' as const, dataCadastro: new Date(2026, 2, 8) },
-    { id: '#004', nome: 'Diego Baltazar', email: 'diego.baltazar@gmail.com', nivel: 'Cliente' as const, dataCadastro: new Date(2026, 2, 8) },
-    { id: '#005', nome: 'Arthur Fudali', email: 'arthur.fudali@gmail.com', nivel: 'Cliente' as const, dataCadastro: new Date(2026, 2, 8) },
-    { id: '#006', nome: 'Amanda Vithoria', email: 'amanda.vithoria@gmail.com', nivel: 'Cliente' as const, dataCadastro: new Date(2026, 2, 8) },
-    { id: '#007', nome: 'Ana Flávia', email: 'ana.flavia@gmail.com', nivel: 'Cliente' as const, dataCadastro: new Date(2026, 2, 8) },
-    { id: '#008', nome: 'Carlos Eduardo', email: 'carlos.eduardo@gmail.com', nivel: 'Cliente' as const, dataCadastro: new Date(2026, 2, 10) },
-    { id: '#009', nome: 'Fernanda Lima', email: 'fernanda.lima@gmail.com', nivel: 'Cliente' as const, dataCadastro: new Date(2026, 2, 11) },
-    { id: '#010', nome: 'Roberto Alves', email: 'roberto.alves@gmail.com', nivel: 'Cliente' as const, dataCadastro: new Date(2026, 2, 12) },
-    { id: '#011', nome: 'Patrícia Sousa', email: 'patricia.sousa@gmail.com', nivel: 'Cliente' as const, dataCadastro: new Date(2026, 2, 13) },
-    { id: '#012', nome: 'Marcelo Nunes', email: 'marcelo.nunes@gmail.com', nivel: 'Cliente' as const, dataCadastro: new Date(2026, 2, 14) },
-    { id: '#013', nome: 'Juliana Mendes', email: 'juliana.mendes@gmail.com', nivel: 'Cliente' as const, dataCadastro: new Date(2026, 2, 15) },
-    { id: '#014', nome: 'Thiago Rocha', email: 'thiago.rocha@gmail.com', nivel: 'Cliente' as const, dataCadastro: new Date(2026, 2, 16) },
-    { id: '#015', nome: 'Larissa Freitas', email: 'larissa.freitas@gmail.com', nivel: 'Cliente' as const, dataCadastro: new Date(2026, 2, 17) },
-    { id: '#016', nome: 'Ricardo Mendonça', email: 'ricardo.mendonca@gmail.com', nivel: 'Cliente' as const, dataCadastro: new Date(2026, 2, 18) },
-    { id: '#017', nome: 'Camila Rocha', email: 'camila.rocha@gmail.com', nivel: 'Cliente' as const, dataCadastro: new Date(2026, 2, 19) },
-    { id: '#018', nome: 'Vinícius Souza', email: 'vinicius.souza@gmail.com', nivel: 'Cliente' as const, dataCadastro: new Date(2026, 2, 20) },
-    { id: '#019', nome: 'Tatiane Oliveira', email: 'tatiane.oliveira@gmail.com', nivel: 'Cliente' as const, dataCadastro: new Date(2026, 2, 21) },
-    { id: '#020', nome: 'Fábio Santos', email: 'fabio.santos@gmail.com', nivel: 'Cliente' as const, dataCadastro: new Date(2026, 2, 22) },
-    { id: '#021', nome: 'Renata Almeida', email: 'renata.almeida@gmail.com', nivel: 'Cliente' as const, dataCadastro: new Date(2026, 2, 23) },
-    { id: '#022', nome: 'Gustavo Lima', email: 'gustavo.lima@gmail.com', nivel: 'Cliente' as const, dataCadastro: new Date(2026, 2, 24) },
-    { id: '#023', nome: 'Carla Nunes', email: 'carla.nunes@gmail.com', nivel: 'Cliente' as const, dataCadastro: new Date(2026, 2, 25) },
-    { id: '#024', nome: 'Paulo César', email: 'paulo.cesar@gmail.com', nivel: 'Cliente' as const, dataCadastro: new Date(2026, 2, 26) },
-    { id: '#025', nome: 'Mariana Dias', email: 'mariana.dias@gmail.com', nivel: 'Cliente' as const, dataCadastro: new Date(2026, 2, 27) },
-    { id: '#026', nome: 'Eduardo Campos', email: 'eduardo.campos@gmail.com', nivel: 'Cliente' as const, dataCadastro: new Date(2026, 2, 28) },
-    { id: '#027', nome: 'Aline Rocha', email: 'aline.rocha@gmail.com', nivel: 'Cliente' as const, dataCadastro: new Date(2026, 2, 28) },
-    { id: '#028', nome: 'Bruno Mendes', email: 'bruno.mendes@gmail.com', nivel: 'Cliente' as const, dataCadastro: new Date(2026, 2, 28) },
-    { id: '#029', nome: 'Vanessa Silva', email: 'vanessa.silva@gmail.com', nivel: 'Cliente' as const, dataCadastro: new Date(2026, 2, 28) },
-    { id: '#030', nome: 'Rafael Costa', email: 'rafael.costa@gmail.com', nivel: 'Cliente' as const, dataCadastro: new Date(2026, 2, 28) },
-  ];
-  return baseUsers;
 };
 
 const ITEMS_PER_PAGE = 7;
 
 export default function Usuarios() {
   const navigate = useNavigate();
-  const [users, setUsers] = useState<User[]>(() => generateMockUsers());
+  const [users, setUsers] = useState<User[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    usuariosService.listarTodos().then((data) => {
+      setUsers(
+        data.map((u) => ({
+          id: u.id,
+          nome: u.nome,
+          email: u.email,
+          nivel: u.nivel.charAt(0).toUpperCase() + u.nivel.slice(1),
+          dataCadastro: new Date(u.data_cadastro),
+        }))
+      );
+      setLoading(false);
+    });
+  }, []);
 
   const [nivelFilter, setNivelFilter] = useState<string>('');
   const [dataFilter, setDataFilter] = useState<Date | undefined>(undefined);
@@ -161,18 +142,15 @@ export default function Usuarios() {
 
   const handleConfirmDelete = async () => {
     if (!selectedUser) return;
-    
+
     setDeleteLoading(true);
-    
+
     try {
-      await new Promise(resolve => setTimeout(resolve, 800));
-      // Remove o usuário da lista
-      setUsers(prevUsers => prevUsers.filter(user => user.id !== selectedUser.id));
+      await usuariosService.deletar(selectedUser.id);
+      setUsers((prev) => prev.filter((u) => u.id !== selectedUser.id));
       setDeleteModalOpen(false);
-      
-      // Se a página atual ficar vazia, volta uma página
-      const newTotalItems = users.length - 1;
-      const newTotalPages = Math.ceil(newTotalItems / ITEMS_PER_PAGE);
+
+      const newTotalPages = Math.ceil((users.length - 1) / ITEMS_PER_PAGE);
       if (currentPage > newTotalPages && newTotalPages > 0) {
         setCurrentPage(newTotalPages);
       }
@@ -235,6 +213,14 @@ export default function Usuarios() {
     return buttons;
   };
 
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64 text-muted-foreground">
+        Carregando usuários...
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-6 p-6">
       <div className="flex items-center justify-between">
@@ -259,7 +245,6 @@ export default function Usuarios() {
               <SelectItem value="all">Todos os níveis</SelectItem>
               <SelectItem value="Administrador">Administrador</SelectItem>
               <SelectItem value="Cliente">Cliente</SelectItem>
-              <SelectItem value="Nível 3">Nível 3</SelectItem>
             </SelectContent>
           </Select>
         </div>

--- a/src/pages/admin/usuarios/EditarUsuario.tsx
+++ b/src/pages/admin/usuarios/EditarUsuario.tsx
@@ -24,8 +24,15 @@ export default function EditarUsuario() {
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [deleteLoading, setDeleteLoading] = useState(false);
 
+  const userId = Number(id);
+
   useEffect(() => {
-    usuariosService.buscarPorId(Number(id)).then((user) => {
+    if (!id || Number.isNaN(userId)) {
+      navigate("/admin/usuarios");
+      return;
+    }
+
+    usuariosService.buscarPorId(userId).then((user) => {
       if (!user) return navigate("/admin/usuarios");
       setInitialData({
         nome: user.nome,
@@ -50,7 +57,7 @@ export default function EditarUsuario() {
         celular: data.telefone.replace(/\D/g, ""),
         ...(data.senha ? { senha: data.senha } : {}),
       };
-      await usuariosService.atualizar(Number(id), payload);
+      await usuariosService.atualizar(userId, payload);
       navigate("/admin/usuarios");
     } catch (error) {
       console.error("Erro ao salvar usuário:", error);
@@ -64,7 +71,7 @@ export default function EditarUsuario() {
   const handleConfirmDelete = async () => {
     setDeleteLoading(true);
     try {
-      await usuariosService.deletar(Number(id));
+      await usuariosService.deletar(userId);
       navigate("/admin/usuarios");
     } catch (error) {
       console.error("Erro ao excluir usuário:", error);

--- a/src/pages/admin/usuarios/EditarUsuario.tsx
+++ b/src/pages/admin/usuarios/EditarUsuario.tsx
@@ -1,34 +1,70 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { UserForm } from "@/components/admin/usuarios/UserForm";
 import { ConfirmDeleteModal } from "@/components/ui/ConfirmDeleteModal";
+import { usuariosService } from "@/services/usuariosService";
 
-const mockUsuario = {
-  id: "001",
-  nome: "Amanda Costa",
-  email: "amanda.costa@gmail.com",
-  documento: "123.456.789-00",
-  telefone: "(11) 99999-8888",
-  tipo: "Administrador" as const,
+type FormData = {
+  nome: string;
+  email: string;
+  documento: string;
+  telefone: string;
+  tipo: "Administrador" | "Cliente";
+  senha: string;
+  confirmarSenha: string;
 };
 
 export default function EditarUsuario() {
   const { id } = useParams();
   const navigate = useNavigate();
-  const usuario = mockUsuario;
 
+  const [initialData, setInitialData] = useState<Partial<FormData> | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [deleteLoading, setDeleteLoading] = useState(false);
 
-  const handleDeleteClick = () => {
-    setDeleteModalOpen(true);
+  useEffect(() => {
+    usuariosService.buscarPorId(Number(id)).then((user) => {
+      if (!user) return navigate("/admin/usuarios");
+      setInitialData({
+        nome: user.nome,
+        email: user.email,
+        documento: user.cpf_cnpj ?? "",
+        telefone: user.celular ?? "",
+        tipo: user.nivel === "administrador" ? "Administrador" : "Cliente",
+        senha: "",
+        confirmarSenha: "",
+      });
+      setLoading(false);
+    });
+  }, [id]);
+
+  const handleSubmit = async (data: FormData) => {
+    setSaving(true);
+    try {
+      const payload = {
+        nome: data.nome,
+        email: data.email,
+        cpfCnpj: data.documento.replace(/\D/g, ""),
+        celular: data.telefone.replace(/\D/g, ""),
+        ...(data.senha ? { senha: data.senha } : {}),
+      };
+      await usuariosService.atualizar(Number(id), payload);
+      navigate("/admin/usuarios");
+    } catch (error) {
+      console.error("Erro ao salvar usuário:", error);
+    } finally {
+      setSaving(false);
+    }
   };
+
+  const handleDeleteClick = () => setDeleteModalOpen(true);
 
   const handleConfirmDelete = async () => {
     setDeleteLoading(true);
     try {
-      await new Promise((resolve) => setTimeout(resolve, 800));
-      console.log(`Usuário ${id} excluído com sucesso`);
+      await usuariosService.deletar(Number(id));
       navigate("/admin/usuarios");
     } catch (error) {
       console.error("Erro ao excluir usuário:", error);
@@ -38,20 +74,19 @@ export default function EditarUsuario() {
     }
   };
 
-  const handleSubmit = (data: any) => {
-    console.log(`Salvar usuário ${id}:`, data);
-    navigate("/admin/usuarios");
-  };
-
-  const handleCancel = () => {
-    navigate("/admin/usuarios");
-  };
+  if (loading || !initialData) {
+    return (
+      <div className="flex items-center justify-center h-64 text-muted-foreground">
+        Carregando usuário...
+      </div>
+    );
+  }
 
   return (
     <div className="p-6 max-w-4xl mx-auto relative">
       <div className="mb-6">
         <h1 className="text-2xl font-bold text-gray-900">
-          Detalhes do usuário #{usuario.id}
+          Detalhes do usuário #{id}
         </h1>
         <p className="text-sm text-gray-500 mt-1">
           Gerencie e atualize as informações deste usuário.
@@ -60,17 +95,18 @@ export default function EditarUsuario() {
 
       <UserForm
         mode="edit"
-        initialData={usuario}
+        initialData={initialData}
         onSubmit={handleSubmit}
-        onCancel={handleCancel}
-        onDelete={handleDeleteClick} 
+        onCancel={() => navigate("/admin/usuarios")}
+        onDelete={handleDeleteClick}
+        saving={saving}
       />
 
       <ConfirmDeleteModal
         open={deleteModalOpen}
         onClose={() => setDeleteModalOpen(false)}
         onConfirm={handleConfirmDelete}
-        userName={usuario.nome}
+        userName={initialData.nome ?? ""}
         loading={deleteLoading}
       />
     </div>

--- a/src/pages/admin/usuarios/NovoUsuario.tsx
+++ b/src/pages/admin/usuarios/NovoUsuario.tsx
@@ -1,26 +1,59 @@
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { UserForm } from "@/components/admin/usuarios/UserForm";
+import { usuariosService } from "@/services/usuariosService";
+
+type FormData = {
+  nome: string;
+  email: string;
+  documento: string;
+  telefone: string;
+  tipo: "Administrador" | "Cliente";
+  senha: string;
+  confirmarSenha: string;
+};
 
 export default function NovoUsuario() {
   const navigate = useNavigate();
+  const [saving, setSaving] = useState(false);
 
-  const handleSubmit = (data: any) => {
-    console.log("Criar usuário:", data);
-    // Futuramente enviar para API
-    navigate("/admin/usuarios");
-  };
+  const handleSubmit = async (data: FormData) => {
+    setSaving(true);
+    try {
+      const cpfCnpj = data.documento.replace(/\D/g, "");
+      const celular = data.telefone.replace(/\D/g, "");
 
-  const handleCancel = () => {
-    navigate("/admin/usuarios");
+      await usuariosService.criar({
+        nome: data.nome,
+        email: data.email,
+        senha: data.senha,
+        nivel: data.tipo === "Administrador" ? "administrador" : "cliente",
+        ...(cpfCnpj ? { cpfCnpj } : {}),
+        ...(celular ? { celular } : {}),
+      });
+
+      navigate("/admin/usuarios");
+    } catch (error) {
+      console.error("Erro ao criar usuário:", error);
+    } finally {
+      setSaving(false);
+    }
   };
 
   return (
     <div className="p-6 max-w-4xl mx-auto relative">
       <div className="mb-6">
         <h1 className="text-2xl font-bold text-gray-900">Criar novo usuário</h1>
-        <p className="text-sm text-gray-500 mt-1">Preencha os campos abaixo para configurar o novo usuário.</p>
+        <p className="text-sm text-gray-500 mt-1">
+          Preencha os campos abaixo para configurar o novo usuário.
+        </p>
       </div>
-      <UserForm mode="create" onSubmit={handleSubmit} onCancel={handleCancel} />
+      <UserForm
+        mode="create"
+        onSubmit={handleSubmit}
+        onCancel={() => navigate("/admin/usuarios")}
+        saving={saving}
+      />
     </div>
   );
 }

--- a/src/services/usuariosService.ts
+++ b/src/services/usuariosService.ts
@@ -1,0 +1,109 @@
+const API_URL = import.meta.env.VITE_API_URL;
+
+const authHeaders = (): HeadersInit => ({
+  'Content-Type': 'application/json',
+  Authorization: `Bearer ${localStorage.getItem('token') ?? ''}`,
+});
+
+export interface UsuarioApi {
+  id: number;
+  nome: string;
+  email: string;
+  nivel: string;
+  cpf_cnpj: string | null;
+  celular: string | null;
+  data_cadastro: string;
+}
+
+export interface CreateUsuarioPayload {
+  nome: string;
+  email: string;
+  senha: string;
+  nivel: 'cliente' | 'administrador';
+  cpfCnpj?: string;
+  celular?: string;
+}
+
+export interface UpdateUsuarioPayload {
+  nome?: string;
+  email?: string;
+  senha?: string;
+  cpfCnpj?: string;
+  celular?: string;
+}
+
+export const usuariosService = {
+  criar: async (payload: CreateUsuarioPayload): Promise<UsuarioApi> => {
+    const response = await fetch(`${API_URL}/usuario/admin/usuarios`, {
+      method: 'POST',
+      headers: authHeaders(),
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const reason = await response.text();
+      console.error(`Erro ao criar usuário (${response.status}):`, reason);
+      throw new Error('Erro ao criar usuário');
+    }
+
+    return await response.json();
+  },
+
+  buscarPorId: async (id: number): Promise<UsuarioApi | null> => {
+    try {
+      const response = await fetch(`${API_URL}/usuario/${id}`, { headers: authHeaders() });
+      if (!response.ok) throw new Error('Erro ao buscar usuário');
+      return await response.json();
+    } catch (error) {
+      console.error('Erro no buscarPorId:', error);
+      return null;
+    }
+  },
+
+  atualizar: async (id: number, payload: UpdateUsuarioPayload): Promise<UsuarioApi | null> => {
+    try {
+      const response = await fetch(`${API_URL}/usuario/${id}`, {
+        method: 'PATCH',
+        headers: authHeaders(),
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        const reason = await response.text();
+        console.error(`Erro ao atualizar usuário (${response.status}):`, reason);
+        throw new Error('Erro ao atualizar usuário');
+      }
+
+      if (response.status === 204) return null;
+      return await response.json();
+    } catch (error) {
+      console.error('Erro no atualizar:', error);
+      throw error;
+    }
+  },
+
+  listarTodos: async (): Promise<UsuarioApi[]> => {
+    try {
+      const response = await fetch(`${API_URL}/usuario`, { headers: authHeaders() });
+      if (!response.ok) throw new Error('Erro ao listar usuários');
+      return await response.json();
+    } catch (error) {
+      console.error('Erro no listarTodos:', error);
+      return [];
+    }
+  },
+
+  deletar: async (id: number): Promise<boolean> => {
+    try {
+      const response = await fetch(`${API_URL}/usuario/${id}`, {
+        method: 'DELETE',
+        headers: authHeaders(),
+      });
+      if (!response.ok) throw new Error('Erro ao excluir usuário');
+      return true;
+    } catch (error) {
+      console.error('Erro no deletar:', error);
+      throw error;
+    }
+  },
+};

--- a/src/services/usuariosService.ts
+++ b/src/services/usuariosService.ts
@@ -1,4 +1,9 @@
-const API_URL = import.meta.env.VITE_API_URL;
+const API_URL = import.meta.env.VITE_API_URL?.trim();
+if (!API_URL) {
+  throw new Error(
+    'A variável de ambiente VITE_API_URL não está definida. Configure-a antes de usar usuariosService.'
+  );
+}
 
 const authHeaders = (): HeadersInit => ({
   'Content-Type': 'application/json',


### PR DESCRIPTION
Este Pull Request integra o módulo de **admin/usuarios** à API, substituindo todos os dados mockados e operações simuladas por chamadas reais aos endpoints do backend. As alterações abrangem criação, listagem, edição e exclusão de usuários no painel administrativo.

**Novo serviço:**

* Criado `src/services/usuariosService.ts` centralizando toda a comunicação com a API do módulo. O serviço implementa os métodos `criar` (POST `/usuario/admin/usuarios`), `listarTodos` (GET `/usuario`), `buscarPorId` (GET `/usuario/:id`), `atualizar` (PATCH `/usuario/:id`) e `deletar` (DELETE `/usuario/:id`). Inclui a função `authHeaders()` que injeta o JWT armazenado no `localStorage` no header `Authorization`, preparada para o merge da branch de autenticação.

**Listagem de usuários (`Usuarios.tsx`):**

* Substituído o mock de 30 usuários estáticos por chamada real a `listarTodos` via `useEffect`, com normalização dos campos retornados pela API.
* Integrado `deletar` no `handleConfirmDelete`, removendo o `setTimeout` simulado.
* Adicionado estado de `loading` com feedback visual enquanto a requisição não retorna.
* Removida a opção "Nível 3" do filtro de nível, que não existe na API.

**Edição de usuários (`EditarUsuario.tsx`):**

* Substituído o mock estático por carregamento real via `buscarPorId` no mount do componente, com mapeamento dos campos da API para o formato do formulário.
* Implementado `handleSubmit` com chamada a `atualizar`, removendo as máscaras dos campos antes do envio e omitindo `senha` quando vazia, alinhado ao comportamento do `PartialType` no `UpdateUsuarioDto`.
* O campo `tipo` (nível do usuário) não é enviado no PATCH pois está explicitamente excluído via `OmitType(['nivel'])` no `UpdateUsuarioDto` — a alteração de nível ficará reservada a um endpoint dedicado.

**Criação de usuários (`NovoUsuario.tsx`):**

* Substituído o `console.log` placeholder pela chamada real a `criar`, mapeando `tipo` para o enum `NivelUsuario` em lowercase e omitindo `cpfCnpj`/`celular` quando vazios para não violar as validações `@Matches` do `CreateAdminUsuarioDto`.
* Adicionado estado `saving` para desabilitar o botão de submit durante o POST.

**Formulário (`UserForm.tsx`):**

* Schema Zod refatorado para `getSchema(mode)`: no modo `create` a senha é obrigatória (mínimo 6 caracteres); no modo `edit` é opcional, alinhado ao `PartialType` do `UpdateUsuarioDto`.
* Adicionada prop `saving` para desabilitar o botão de submit e exibir o texto "Salvando..." durante operações assíncronas, prevenindo duplo envio.

---

closes #104
