### PR TITLE
feat: integrar chat com websocket e sessão

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,6 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3599,7 +3598,6 @@
       "version": "24.12.0",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3608,7 +3606,6 @@
       "version": "19.2.14",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3617,7 +3614,6 @@
       "version": "19.2.3",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3667,7 +3663,6 @@
       "version": "8.57.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.1",
         "@typescript-eslint/types": "8.57.1",
@@ -3915,7 +3910,6 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4070,7 +4064,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4196,8 +4189,7 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -4382,8 +4374,7 @@
     },
     "node_modules/embla-carousel": {
       "version": "8.6.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -4508,7 +4499,6 @@
       "version": "9.39.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5001,8 +4991,7 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -5454,7 +5443,6 @@
     "node_modules/picomatch": {
       "version": "4.0.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5479,7 +5467,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5524,7 +5511,6 @@
     "node_modules/react": {
       "version": "19.2.4",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5554,7 +5540,6 @@
     "node_modules/react-dom": {
       "version": "19.2.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5584,7 +5569,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.74.0.tgz",
       "integrity": "sha512-yR6wHr99p9wFv686jhRWVSFhUvDvNbdUf2dKlbno8/VKOCuoNobDGC6S+M2dua9A9Yo8vpcrp8assIYbsZCQ9g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -5626,8 +5610,7 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-leaflet": {
       "version": "5.0.0",
@@ -5648,7 +5631,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -5821,8 +5803,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -6001,8 +5982,7 @@
     },
     "node_modules/tailwindcss": {
       "version": "4.2.1",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -6074,7 +6054,6 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6224,7 +6203,6 @@
     "node_modules/vite": {
       "version": "7.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -6366,7 +6344,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -13,6 +13,7 @@ import {
   LogOut
 } from "lucide-react";
 import logoDespachante from "@/assets/logo-despachante.png";
+import { clearSession } from "@/lib/authStorage";
 
 interface AdminSidebarProps {
   onLinkClick?: () => void;
@@ -36,7 +37,7 @@ export function AdminSidebar({ onLinkClick }: AdminSidebarProps) {
   ];
 
   const handleLogout = async () => {
-    localStorage.removeItem("admin_token");
+    clearSession();
     sessionStorage.clear();
     navigate("/login");
   };

--- a/src/components/chat/AdminChatModal.tsx
+++ b/src/components/chat/AdminChatModal.tsx
@@ -1,61 +1,241 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { CircleUserRound, Search, Send, Smile, X } from "lucide-react";
-import chatMock from "../../mocks/chat.mock.json"
+import { toast } from "sonner";
+import { getChatSocket } from "@/services/socket";
+import { getStoredUser, getToken } from "@/lib/authStorage";
 
-type ChatMessage = {
-  id: number,
+type UiMessage = {
+  id: string;
   sender: "admin" | "client";
   text: string;
   time: string;
-}
+};
 
 type ChatContact = {
-  id: number
-  name: string
-  online: boolean
-  unreadCount: number
-  lastMessage: string
-  lastMessageTime: string
-}
+  userId: string;
+  name: string;
+  online: boolean;
+};
 
-type ChatMessagesByContact = Record<string, ChatMessage[]>
+type ChatMessagesByContact = Record<string, UiMessage[]>;
 
 type AdminChatModalProps = {
-  open: boolean
-  onClose: () => void
+  open: boolean;
+  onClose: () => void;
+  sessionUnreadCounts?: Record<string, number>;
+  onConsumeSessionUnread?: (sessionId: string) => void;
+};
+
+function normalizeText(value: string): string {
+  return value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .trim();
+}
+
+function formatChatTime(iso: string): string {
+  try {
+    return new Date(iso).toLocaleTimeString("pt-BR", {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return "";
+  }
+}
+
+function isClientBroadcastPayload(
+  d: unknown,
+): d is { userId: string; text: string; timestamp: string; nome: string } {
+  if (typeof d !== "object" || d === null) return false;
+  const o = d as Record<string, unknown>;
+  if ("type" in o) return false;
+  return (
+    typeof o.userId === "string" &&
+    typeof o.text === "string" &&
+    typeof o.timestamp === "string"
+  );
+}
+
+type ServerMsg = { nome: string; text: string; timestamp: string; userId?: string };
+
+function serverRowToUi(m: ServerMsg, idx: number): UiMessage {
+  return {
+    id: `srv-${idx}-${m.timestamp}-${m.text.slice(0, 6)}`,
+    sender: m.nome === "Atendente" ? "admin" : "client",
+    text: m.text,
+    time: formatChatTime(m.timestamp),
+  };
 }
 
 export default function AdminChatModal({
   open,
   onClose,
+  sessionUnreadCounts = {},
+  onConsumeSessionUnread,
 }: AdminChatModalProps) {
-  const contacts = chatMock.contacts as ChatContact[];
+  const [blocked, setBlocked] = useState(false);
+  const [search, setSearch] = useState("");
+  const [contacts, setContacts] = useState<ChatContact[]>([]);
+  const [selectedContactId, setSelectedContactId] = useState("");
+  const [inputValue, setInputValue] = useState("");
+  const [messagesByContact, setMessagesByContact] = useState<ChatMessagesByContact>(
+    {},
+  );
+  const scrollRef = useRef<HTMLDivElement>(null);
 
-  const [search, setSearch] = useState("")
-  const [selectedContactId, setSelectedContactId] = useState<number>(
-    contacts?.[0]?.id ?? 1
-  )
+  useEffect(() => {
+    if (!open) return;
 
-  const [inputValue, setInputValue] = useState("")
-  const [messagesByContact, setMessagesByContact] = useState<ChatMessagesByContact>(chatMock.messages as ChatMessagesByContact)
+    const token = getToken();
+    const user = getStoredUser();
+    if (!token || user?.nivel !== "administrador") {
+      setBlocked(true);
+      return;
+    }
+
+    setBlocked(false);
+
+    const s = getChatSocket(token);
+
+    const onChat = (data: unknown) => {
+      if (!data || typeof data !== "object") return;
+      const d = data as Record<string, unknown>;
+
+      if (d.type === "users" && Array.isArray(d.users)) {
+        const rows = d.users as { userId: string; nome: string }[];
+        setContacts(
+          rows.map((u) => ({
+            userId: u.userId,
+            name: u.nome,
+            online: true,
+          })),
+        );
+        return;
+      }
+
+      if (d.type === "history_for_user" && typeof d.userId === "string" && Array.isArray(d.messages)) {
+        const uid = d.userId;
+        const rows = d.messages as ServerMsg[];
+        const mapped = rows.map((m, i) => serverRowToUi(m, i));
+        setMessagesByContact((prev) => ({
+          ...prev,
+          [uid]: mapped,
+        }));
+        return;
+      }
+
+      if (d.type === "userDisconnected" && typeof d.userId === "string") {
+        const uid = d.userId;
+        setContacts((prev) => prev.filter((c) => c.userId !== uid));
+        setMessagesByContact((prev) => {
+          const next = { ...prev };
+          delete next[uid];
+          return next;
+        });
+        return;
+      }
+
+      if (d.type === "error" && typeof d.msg === "string") {
+        toast.error(d.msg);
+        return;
+      }
+
+      if (d.type === "status" && typeof d.msg === "string") {
+        toast.message(d.msg);
+        return;
+      }
+
+      if (isClientBroadcastPayload(data)) {
+        const msg: UiMessage = {
+          id: `c-${data.timestamp}-${data.text.slice(0, 8)}`,
+          sender: "client",
+          text: data.text,
+          time: formatChatTime(data.timestamp),
+        };
+        setMessagesByContact((prev) => ({
+          ...prev,
+          [data.userId]: [...(prev[data.userId] ?? []), msg],
+        }));
+      }
+    };
+
+    const onConnectErr = (err: Error) => {
+      toast.error(err.message || "Falha ao conectar no chat");
+    };
+
+    s.on("chat", onChat);
+    s.on("connect_error", onConnectErr);
+
+    queueMicrotask(() => {
+      s.emit("chat", { type: "admin_resync" });
+    });
+
+    return () => {
+      s.off("chat", onChat);
+      s.off("connect_error", onConnectErr);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (contacts.length === 0) {
+      setSelectedContactId("");
+      return;
+    }
+    setSelectedContactId((prev) => {
+      if (prev && contacts.some((c) => c.userId === prev)) return prev;
+      return contacts[0].userId;
+    });
+  }, [contacts]);
+
+  useEffect(() => {
+    const activeIds = new Set(contacts.map((c) => c.userId));
+    setMessagesByContact((prev) => {
+      const next: ChatMessagesByContact = {};
+      for (const [userId, msgs] of Object.entries(prev)) {
+        if (activeIds.has(userId)) next[userId] = msgs;
+      }
+      return next;
+    });
+  }, [contacts]);
 
   const filteredContacts = useMemo(() => {
+    const q = normalizeText(search);
+    if (!q) return contacts;
     return contacts.filter((contact) =>
-      contact.name.toLowerCase().includes(search.toLowerCase())
+      normalizeText(contact.name).includes(q),
     );
   }, [contacts, search]);
 
-  const selectedContact = contacts.find((contact) => contact.id === selectedContactId);
+  const selectedContact = contacts.find((c) => c.userId === selectedContactId);
+  const selectedMessages = messagesByContact[selectedContactId] ?? [];
 
-  const selectedMessages = messagesByContact[String(selectedContactId)] ?? [];
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [selectedMessages, selectedContactId]);
+
+  const handleSelectContact = (userId: string) => {
+    setSelectedContactId(userId);
+    onConsumeSessionUnread?.(userId);
+  };
 
   const handleSendMessage = () => {
     const trimmedValue = inputValue.trim();
+    if (!trimmedValue || blocked || !selectedContactId) return;
 
-    if (!trimmedValue) return;
+    const token = getToken();
+    if (!token) return;
 
-    const newMessage: ChatMessage = {
-      id: Date.now(),
+    const s = getChatSocket(token);
+    if (!s.connected) {
+      toast.error("Chat desconectado.");
+      return;
+    }
+
+    const newMessage: UiMessage = {
+      id: `a-${Date.now()}`,
       sender: "admin",
       text: trimmedValue,
       time: "Agora",
@@ -63,21 +243,48 @@ export default function AdminChatModal({
 
     setMessagesByContact((prev) => ({
       ...prev,
-      [String(selectedContactId)]: [
-        ...(prev[String(selectedContactId)] ?? []),
-        newMessage,
-      ],
+      [selectedContactId]: [...(prev[selectedContactId] ?? []), newMessage],
     }));
 
+    s.emit("chat", {
+      type: "message",
+      text: trimmedValue,
+      to: selectedContactId,
+    });
     setInputValue("");
   };
 
   if (!open) return null;
 
+  if (blocked) {
+    return (
+      <div
+        className="
+        fixed z-50 bg-white overflow-hidden rounded-[28px] shadow-[0_18px_40px_rgba(0,0,0,0.18)]
+        bottom-20 right-4 w-[calc(100vw-32px)] h-[80vh] flex flex-col p-6
+        md:bottom-28 md:right-12 md:w-[620px] md:h-[520px]
+      "
+      >
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold text-zinc-800">Chat</h2>
+          <button type="button" onClick={onClose} aria-label="Fechar chat">
+            <X size={22} />
+          </button>
+        </div>
+        <p className="text-sm text-zinc-600">
+          Faça login com uma conta de administrador para atender pelo chat.
+        </p>
+      </div>
+    );
+  }
+
+  const bubbleBase =
+    "max-w-[90%] min-w-0 rounded-2xl px-4 py-3 text-sm shadow-sm break-words [overflow-wrap:anywhere]";
+
   return (
     <div
       className="
-        fixed z- bg-white overflow-hidden rounded-[28px] shadow-[0_18px_40px_rgba(0,0,0,0.18)]
+        fixed z-50 bg-white overflow-hidden rounded-[28px] shadow-[0_18px_40px_rgba(0,0,0,0.18)]
         bottom-20 right-4 w-[calc(100vw-32px)] h-[80vh] flex-col flex
         md:bottom-28 md:right-12 md:w-[620px] md:h-[520px] md:flex-row md:max-w-[calc(100vw-48px)]
       "
@@ -96,50 +303,57 @@ export default function AdminChatModal({
         </div>
 
         <div className="flex-1 overflow-y-auto pb-3">
-          {filteredContacts.map((contact) => {
-            const isActive = selectedContactId === contact.id;
+          {filteredContacts.length === 0 ? (
+            <p className="px-4 text-sm text-zinc-500">
+              Nenhum cliente no chat. Peça para um cliente entrar no portal (logado) para aparecer aqui.
+            </p>
+          ) : (
+            filteredContacts.map((contact) => {
+              const isActive = selectedContactId === contact.userId;
+              const nUnread = sessionUnreadCounts[contact.userId] ?? 0;
+              return (
+                <button
+                  key={contact.userId}
+                  type="button"
+                  onClick={() => handleSelectContact(contact.userId)}
+                  className={`relative flex w-full items-center gap-3 px-4 py-3 text-left transition-colors ${
+                    isActive ? "bg-zinc-200" : "hover:bg-zinc-100"
+                  } ${isActive ? "text-secondary" : "text-zinc-800"}`}
+                >
+                  {isActive && (
+                    <span className="absolute left-0 top-0 h-full w-1 bg-secondary" />
+                  )}
 
-            return (
-              <button
-                key={contact.id}
-                onClick={() => setSelectedContactId(contact.id)}
-                className={`relative flex w-full items-center gap-3 px-4 py-3 text-left transition-colors ${
-                  isActive ? "bg-zinc-200" : "hover:bg-zinc-100"
-                } ${isActive ? "text-secondary" : "text-zinc-800"}`}
-              >
-                {isActive && (
-                  <span className="absolute left-0 top-0 h-full w-1 bg-secondary" />
-                )}
+                  <div className="relative shrink-0">
+                    <div className="flex h-11 w-11 items-center justify-center rounded-full bg-zinc-200 text-secondary">
+                      <CircleUserRound size={24} />
+                    </div>
 
-                <div className="relative shrink-0">
-                  <div className="flex h-11 w-11 items-center justify-center rounded-full bg-zinc-200 text-secondary">
-                    <CircleUserRound size={24} />
+                    <span
+                      className={`absolute bottom-0 right-0 h-3.5 w-3.5 rounded-full border-2 border-white ${
+                        contact.online ? "bg-green-500" : "bg-red-500"
+                      }`}
+                    />
                   </div>
 
-                  <span
-                    className={`absolute bottom-0 right-0 h-3.5 w-3.5 rounded-full border-2 border-white ${
-                      contact.online ? "bg-green-500" : "bg-red-500"
-                    }`}
-                  />
-                </div>
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-semibold text-zinc-800">
+                      {contact.name}
+                    </p>
+                    <p className="truncate text-xs text-zinc-500">
+                      {contact.userId}
+                    </p>
+                  </div>
 
-                <div className="min-w-0 flex-1">
-                  <p className="truncate text-sm font-semibold text-zinc-800">
-                    {contact.name}
-                  </p>
-                  <p className="truncate text-xs text-zinc-500">
-                    {contact.lastMessage}
-                  </p>
-                </div>
-
-                {contact.unreadCount > 0 && (
-                  <span className="flex h-5 min-w-5 shrink-0 items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-bold text-white">
-                    {contact.unreadCount > 9 ? "9+" : contact.unreadCount}
-                  </span>
-                )}
-              </button>
-            );
-          })}
+                  {nUnread > 0 && (
+                    <span className="flex h-6 min-w-6 shrink-0 items-center justify-center rounded-full bg-red-500 px-1.5 text-[11px] font-bold text-white">
+                      {nUnread > 99 ? "99+" : nUnread}
+                    </span>
+                  )}
+                </button>
+              );
+            })
+          )}
         </div>
       </aside>
 
@@ -154,27 +368,30 @@ export default function AdminChatModal({
             </h2>
           </div>
 
-          <button onClick={onClose} aria-label="Fechar chat" className="cursor-pointer shrink-0">
+          <button type="button" onClick={onClose} aria-label="Fechar chat" className="cursor-pointer shrink-0">
             <X size={22} />
           </button>
         </div>
 
-        <div className="flex flex-1 flex-col gap-3 overflow-y-auto p-4">
+        <div
+          ref={scrollRef}
+          className="flex flex-1 flex-col gap-3 overflow-y-auto overflow-x-hidden p-4 min-w-0"
+        >
           {selectedMessages.map((message) => (
             <div
               key={message.id}
-              className={`flex ${
+              className={`flex min-w-0 ${
                 message.sender === "admin" ? "justify-end" : "justify-start"
               }`}
             >
               <div
-                className={`max-w-[90%] rounded-2xl px-4 py-3 text-sm shadow-sm ${
+                className={`${bubbleBase} ${
                   message.sender === "admin"
                     ? "bg-white text-zinc-800 after:content-[''] after:absolute after:bottom-0 after:right-[-6px] after:w-3 after:h-3 after:bg-white after:rotate-45 after:rounded-sm"
                     : "bg-primary text-white after:content-[''] after:absolute after:bottom-0 after:left-[-6px] after:w-3 after:h-3 after:bg-primary after:rotate-45 after:rounded-sm"
                 }`}
               >
-                <p>{message.text}</p>
+                <p className="whitespace-pre-wrap">{message.text}</p>
                 <span className="mt-1 block text-[11px] opacity-70">
                   {message.time}
                 </span>
@@ -184,24 +401,28 @@ export default function AdminChatModal({
         </div>
 
         <div className="flex items-center gap-2 p-4 shrink-0">
-          <button 
+          <button
+            type="button"
             className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-white text-secondary cursor-pointer transition hover:brightness-95"
             aria-label="Enviar emoji"
           >
             <Smile size={24} />
           </button>
-          
+
           <input
             value={inputValue}
             onChange={(e) => setInputValue(e.target.value)}
             onKeyDown={(e) => e.key === "Enter" && handleSendMessage()}
             placeholder="Digite sua mensagem"
+            disabled={!selectedContactId}
             className="flex-1 min-w-0 rounded-full border border-zinc-300 px-4 py-3 text-sm outline-none"
           />
 
           <button
+            type="button"
             onClick={handleSendMessage}
-            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-secondary text-white cursor-pointer transition hover:brightness-95"
+            disabled={!selectedContactId}
+            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-secondary text-white cursor-pointer transition hover:brightness-95 disabled:opacity-50"
             aria-label="Enviar mensagem"
           >
             <Send size={18} />

--- a/src/components/chat/ChatFloatingButton.tsx
+++ b/src/components/chat/ChatFloatingButton.tsx
@@ -1,35 +1,33 @@
 import { MessageSquare } from "lucide-react";
-// import { Button } from "../ui/button";
 
 type ChatFloatingButtonProps = {
   onClick: () => void;
   unreadCount?: number;
-}
+};
 
 export default function ChatFloatingButton({
   onClick,
   unreadCount = 0,
 }: ChatFloatingButtonProps) {
-  return(
+  return (
     <button
+      type="button"
       onClick={onClick}
       aria-label="Abrir chat"
       className="
-        fixed z- flex h-14 w-14 md:h-16 md:w-16 items-center justify-center rounded-full 
+        fixed z-50 flex h-14 w-14 md:h-16 md:w-16 items-center justify-center rounded-full 
         bg-primary text-white shadow-[0_10px_25px_rgba(0,0,0,0.22)] transition-all duration-200 
         hover:scale-105 hover:bg-secondary active:scale-95
         bottom-6 right-4 md:bottom-10 md:right-12
-      " 
+      "
     >
-      <MessageSquare size={22} />
+      <MessageSquare size={22} className="shrink-0" />
 
       {unreadCount > 0 && (
-        <span
-          className="absolute -top-1 -right-1 flex h-7 w-7 items-center justify-center rounded-full bg-red-500 text-white text-xs font-bold"
-        >
-          {unreadCount > 9 ? "9+" : unreadCount}
+        <span className="absolute -top-1 -right-1 flex h-7 min-w-7 px-1 items-center justify-center rounded-full bg-red-500 text-white text-xs font-bold">
+          {unreadCount > 99 ? "99+" : unreadCount}
         </span>
       )}
     </button>
-  )
+  );
 }

--- a/src/components/chat/ClientChatModal.tsx
+++ b/src/components/chat/ClientChatModal.tsx
@@ -1,9 +1,11 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { CarFront, Send, X, Smile } from "lucide-react";
-import chatMock from "../../mocks/chat.mock.json"
+import { toast } from "sonner";
+import { getChatSocket } from "@/services/socket";
+import { getStoredUser, getToken } from "@/lib/authStorage";
 
 type ChatMessage = {
-  id: number;
+  id: string;
   sender: "admin" | "client";
   text: string;
   time: string;
@@ -14,37 +16,162 @@ type ClientChatModalProps = {
   onClose: () => void;
 };
 
+function formatChatTime(iso: string): string {
+  try {
+    return new Date(iso).toLocaleTimeString("pt-BR", {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return "";
+  }
+}
+
+type HistoryRow = { nome: string; text: string; timestamp: string };
+
 export default function ClientChatModal({
   open,
   onClose,
 }: ClientChatModalProps) {
-  const [messages, setMessages] = useState<ChatMessage[]>(
-    chatMock.messages["1"] as ChatMessage[]
-  );
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [inputValue, setInputValue] = useState("");
+  const [blocked, setBlocked] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const token = getToken();
+    const user = getStoredUser();
+    if (!token || user?.nivel !== "cliente") {
+      setBlocked(true);
+      return;
+    }
+    setBlocked(false);
+
+    const s = getChatSocket(token);
+
+    const onChat = (data: unknown) => {
+      if (!data || typeof data !== "object") return;
+      const d = data as Record<string, unknown>;
+
+      if (d.type === "history" && Array.isArray(d.messages)) {
+        const rows = d.messages as HistoryRow[];
+        setMessages(
+          rows.map((m, i) => ({
+            id: `h-${i}-${m.timestamp}`,
+            sender: m.nome === "Atendente" ? "admin" : "client",
+            text: m.text,
+            time: formatChatTime(m.timestamp),
+          })),
+        );
+        return;
+      }
+
+      if (d.type === "message" && typeof d.text === "string") {
+        const textIn = d.text;
+        const tsIn = d.timestamp;
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: `in-${Date.now()}`,
+            sender: "admin",
+            text: textIn,
+            time: typeof tsIn === "string" ? formatChatTime(tsIn) : "",
+          },
+        ]);
+        return;
+      }
+
+      if (d.type === "error" && typeof d.msg === "string") {
+        toast.error(d.msg);
+        return;
+      }
+
+      if (d.type === "status" && typeof d.msg === "string") {
+        toast.message(d.msg);
+      }
+    };
+
+    const onConnectErr = (err: Error) => {
+      toast.error(err.message || "Falha ao conectar no chat");
+    };
+
+    s.on("chat", onChat);
+    s.on("connect_error", onConnectErr);
+
+    queueMicrotask(() => {
+      s.emit("chat", { type: "resync" });
+    });
+
+    return () => {
+      s.off("chat", onChat);
+      s.off("connect_error", onConnectErr);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [messages]);
 
   const handleSendMessage = () => {
     const trimmedValue = inputValue.trim();
+    if (!trimmedValue || blocked) return;
 
-    if (!trimmedValue) return;
+    const token = getToken();
+    if (!token) return;
 
-    const newMessage: ChatMessage = {
-      id: Date.now(),
-      sender: "client",
-      text: trimmedValue,
-      time: "Agora",
-    };
+    const s = getChatSocket(token);
+    if (!s.connected) {
+      toast.error("Chat desconectado. Aguarde ou abra de novo.");
+      return;
+    }
 
-    setMessages((prev) => [...prev, newMessage]);
+    setMessages((prev) => [
+      ...prev,
+      {
+        id: `out-${Date.now()}`,
+        sender: "client",
+        text: trimmedValue,
+        time: "Agora",
+      },
+    ]);
+    s.emit("chat", { type: "message", text: trimmedValue });
     setInputValue("");
   };
 
   if (!open) return null;
 
+  if (blocked) {
+    return (
+      <div
+        className="
+        fixed z-50 bg-white overflow-hidden rounded-[28px] shadow-[0_18px_40px_rgba(0,0,0,0.18)]
+        bottom-20 right-4 w-[calc(100vw-32px)] sm:w-[380px] flex flex-col p-6
+        md:bottom-28 md:right-12
+      "
+      >
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold text-zinc-800">Chat</h2>
+          <button type="button" onClick={onClose} aria-label="Fechar chat">
+            <X size={22} />
+          </button>
+        </div>
+        <p className="text-sm text-zinc-600">
+          Faça login com uma conta de cliente para usar o chat ao vivo.
+        </p>
+      </div>
+    );
+  }
+
+  const bubbleBase =
+    "max-w-[75%] min-w-0 rounded-2xl px-4 py-3 text-sm shadow-sm break-words [overflow-wrap:anywhere]";
+
   return (
     <div
       className="
-        fixed z- bg-white overflow-hidden rounded-[28px] shadow-[0_18px_40px_rgba(0,0,0,0.18)]
+        fixed z-50 bg-white overflow-hidden rounded-[28px] shadow-[0_18px_40px_rgba(0,0,0,0.18)]
         bottom-20 right-4 w-[calc(100vw-32px)] sm:w-[380px] flex flex-col
         md:bottom-28 md:right-12
       "
@@ -58,27 +185,30 @@ export default function ClientChatModal({
           <h2 className="text-lg font-semibold truncate">Administrador Bortone</h2>
         </div>
 
-        <button onClick={onClose} aria-label="Fechar chat" className="cursor-pointer shrink-0">
+        <button type="button" onClick={onClose} aria-label="Fechar chat" className="cursor-pointer shrink-0">
           <X size={22} />
         </button>
       </div>
 
-      <div className="flex h-[50vh] sm:h-[420px] flex-col gap-3 overflow-y-auto bg-slate-100 p-4">
+      <div
+        ref={scrollRef}
+        className="flex h-[50vh] sm:h-[420px] flex-col gap-3 overflow-y-auto bg-slate-100 p-4"
+      >
         {messages.map((message) => (
           <div
             key={message.id}
-            className={`flex ${
+            className={`flex min-w-0 ${
               message.sender === "client" ? "justify-end" : "justify-start"
             }`}
           >
             <div
-              className={`max-w-[75%] rounded-2xl px-4 py-3 text-sm shadow-sm ${
+              className={`${bubbleBase} ${
                 message.sender === "client"
                   ? "bg-white text-zinc-800 after:content-[''] after:absolute after:bottom-0 after:right-[-6px] after:w-3 after:h-3 after:bg-white after:rotate-45 after:rounded-sm"
                   : "bg-primary text-white after:content-[''] after:absolute after:bottom-0 after:left-[-6px] after:w-3 after:h-3 after:bg-primary after:rotate-45 after:rounded-sm"
               }`}
             >
-              <p>{message.text}</p>
+              <p className="whitespace-pre-wrap">{message.text}</p>
               <span className="mt-1 block text-[11px] opacity-70">
                 {message.time}
               </span>
@@ -87,15 +217,15 @@ export default function ClientChatModal({
         ))}
       </div>
 
-      {/* CORREÇÃO DO BOTÃO CORTADO AQUI (min-w-0 no input, shrink-0 nos botões) */}
       <div className="flex items-center gap-2 p-4 shrink-0">
-        <button 
-            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-white text-secondary cursor-pointer transition hover:brightness-95"
-            aria-label="Enviar emoji"
-          >
-            <Smile size={24} />
-          </button>
-          
+        <button
+          type="button"
+          className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-white text-secondary cursor-pointer transition hover:brightness-95"
+          aria-label="Enviar emoji"
+        >
+          <Smile size={24} />
+        </button>
+
         <input
           value={inputValue}
           onChange={(e) => setInputValue(e.target.value)}
@@ -105,6 +235,7 @@ export default function ClientChatModal({
         />
 
         <button
+          type="button"
           onClick={handleSendMessage}
           className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-secondary cursor-pointer text-white transition hover:brightness-95"
           aria-label="Enviar mensagem"

--- a/src/components/layout/AdminLayout.tsx
+++ b/src/components/layout/AdminLayout.tsx
@@ -1,15 +1,31 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Outlet } from "react-router-dom";
 import { AdminSidebar } from "@/components/admin/AdminSidebar";
 import { FiX } from "react-icons/fi";
 import AdminChatModal from "../chat/AdminChatModal";
 import ChatFloatingButton from "../chat/ChatFloatingButton";
 import { useLocation } from "react-router-dom";
+import { getStoredUser, getToken } from "@/lib/authStorage";
+import { getChatSocket } from "@/services/socket";
+import { useChatNotifications } from "@/hooks/useChatNotifications";
 
 export function AdminLayout() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [isChatOpen, setIsChatOpen] = useState(false);
   const location = useLocation();
+
+  const at = getToken();
+  const au = getStoredUser();
+  const showAdminChat = !!(at && au?.nivel === "administrador");
+
+  useEffect(() => {
+    if (!showAdminChat) return;
+    const tok = getToken();
+    if (tok) getChatSocket(tok);
+  }, [showAdminChat]);
+
+  const { floatingCount, sessionUnread, consumeSessionUnread } =
+    useChatNotifications("administrador", isChatOpen);
 
   const noPaddingRoutes = [
     "/admin/dashboard",
@@ -78,15 +94,20 @@ export function AdminLayout() {
 
       </main>
 
-      <AdminChatModal
-        open={isChatOpen}
-        onClose={() => setIsChatOpen(false)}
-      />
-
-      <ChatFloatingButton
-        onClick={() => setIsChatOpen((prev) => !prev)}
-        unreadCount={1}
-      />
+      {showAdminChat && (
+        <>
+          <AdminChatModal
+            open={isChatOpen}
+            onClose={() => setIsChatOpen(false)}
+            sessionUnreadCounts={sessionUnread}
+            onConsumeSessionUnread={consumeSessionUnread}
+          />
+          <ChatFloatingButton
+            onClick={() => setIsChatOpen((prev) => !prev)}
+            unreadCount={floatingCount}
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/layout/ClienteLayout.tsx
+++ b/src/components/layout/ClienteLayout.tsx
@@ -1,13 +1,28 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Outlet } from "react-router-dom";
 import { ClienteSidebar } from "@/components/layout/ClienteSidebar";
 import { FiMenu, FiX } from "react-icons/fi";
 import ClientChatModal from "../chat/ClientChatModal";
 import ChatFloatingButton from "../chat/ChatFloatingButton";
+import { getStoredUser, getToken } from "@/lib/authStorage";
+import { getChatSocket } from "@/services/socket";
+import { useChatNotifications } from "@/hooks/useChatNotifications";
 
 export function ClienteLayout() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [isChatOpen, setIsChatOpen] = useState(false);
+
+  const t = getToken();
+  const u = getStoredUser();
+  const showClienteChat = !!(t && u?.nivel === "cliente");
+
+  useEffect(() => {
+    if (!showClienteChat) return;
+    const tok = getToken();
+    if (tok) getChatSocket(tok);
+  }, [showClienteChat]);
+
+  const { floatingCount } = useChatNotifications("cliente", isChatOpen);
 
   return (
     <div className="flex h-screen w-full bg-zinc-50 font-sans overflow-hidden">
@@ -73,16 +88,18 @@ export function ClienteLayout() {
         </div>
         
       </main>
-      <ClientChatModal
-        open={isChatOpen}
-        onClose={() => setIsChatOpen(false)}
-      />
-
-      <ChatFloatingButton
-              onClick={() => setIsChatOpen((prev) => !prev)}
-              unreadCount={1}
-              />
-
+      {showClienteChat && (
+        <>
+          <ClientChatModal
+            open={isChatOpen}
+            onClose={() => setIsChatOpen(false)}
+          />
+          <ChatFloatingButton
+            onClick={() => setIsChatOpen((prev) => !prev)}
+            unreadCount={floatingCount}
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/layout/ClienteSidebar.tsx
+++ b/src/components/layout/ClienteSidebar.tsx
@@ -4,6 +4,7 @@ import { FaCar } from "react-icons/fa";
 import { Button } from "@/components/ui/button";
 import { NavLink, useNavigate } from "react-router-dom";
 import logoDespachante from "@/assets/logo-despachante.png";
+import { clearSession, getStoredUser } from "@/lib/authStorage";
 
 type SidebarLink = {
   name: string;
@@ -28,12 +29,13 @@ interface Cliente {
 
 export function ClienteSidebar({ onLinkClick }: ClienteSidebarProps) {
   const navigate = useNavigate();
-  const [currentUser, setCurrentUser] = useState<Cliente | null>({
-    nome: "Arthur Fukunaga F...",
-  });
+  const stored = getStoredUser();
+  const [currentUser, setCurrentUser] = useState<Cliente | null>(
+    stored ? { nome: stored.nome } : null,
+  );
 
   const handleLogout = async () => {
-    localStorage.removeItem("token");
+    clearSession();
     sessionStorage.clear();
     setCurrentUser(null);
     navigate("/login");

--- a/src/hooks/useChatNotifications.ts
+++ b/src/hooks/useChatNotifications.ts
@@ -1,0 +1,85 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { getStoredUser, getToken } from "@/lib/authStorage";
+import { getChatSocket } from "@/services/socket";
+
+function isClientBroadcastPayload(
+  d: unknown,
+): d is { userId: string; text: string; timestamp: string } {
+  if (typeof d !== "object" || d === null) return false;
+  const o = d as Record<string, unknown>;
+  if ("type" in o) return false;
+  return (
+    typeof o.userId === "string" &&
+    typeof o.text === "string" &&
+    typeof o.timestamp === "string"
+  );
+}
+
+type Role = "cliente" | "administrador";
+
+/**
+ * Mantém contagem de não lidas enquanto o chat está fechado (socket permanece ativo no layout).
+ */
+export function useChatNotifications(role: Role, chatOpen: boolean) {
+  const openRef = useRef(chatOpen);
+  openRef.current = chatOpen;
+
+  const [floatingCount, setFloatingCount] = useState(0);
+  const [sessionUnread, setSessionUnread] = useState<Record<string, number>>(
+    {},
+  );
+
+  useEffect(() => {
+    if (chatOpen) {
+      setFloatingCount(0);
+      setSessionUnread({});
+    }
+  }, [chatOpen]);
+
+  useEffect(() => {
+    const user = getStoredUser();
+    const token = getToken();
+    if (!token || user?.nivel !== role) return;
+
+    const s = getChatSocket(token);
+
+    const onChat = (data: unknown) => {
+      if (openRef.current) return;
+
+      if (role === "cliente") {
+        const d = data as Record<string, unknown>;
+        if (d?.type === "message" && typeof d.text === "string") {
+          setFloatingCount((n) => n + 1);
+        }
+        return;
+      }
+
+      if (isClientBroadcastPayload(data)) {
+        const uid = data.userId;
+        setFloatingCount((n) => n + 1);
+        setSessionUnread((prev) => ({
+          ...prev,
+          [uid]: (prev[uid] ?? 0) + 1,
+        }));
+      }
+    };
+
+    s.on("chat", onChat);
+    return () => {
+      s.off("chat", onChat);
+    };
+  }, [role]);
+
+  const consumeSessionUnread = useCallback((sessionId: string) => {
+    setSessionUnread((prev) => {
+      const n = prev[sessionId] ?? 0;
+      if (n <= 0) return prev;
+      setFloatingCount((t) => Math.max(0, t - n));
+      const next = { ...prev };
+      delete next[sessionId];
+      return next;
+    });
+  }, []);
+
+  return { floatingCount, sessionUnread, consumeSessionUnread };
+}

--- a/src/lib/authStorage.ts
+++ b/src/lib/authStorage.ts
@@ -1,0 +1,38 @@
+import { disconnectChatSocket } from "@/services/socket";
+
+const TOKEN_KEY = "bortone_auth_token";
+const USER_KEY = "bortone_auth_user";
+
+export type StoredUser = {
+  id: number;
+  nome: string;
+  email: string;
+  nivel: string;
+};
+
+export function setSession(token: string, usuario: StoredUser): void {
+  localStorage.setItem(TOKEN_KEY, token);
+  localStorage.setItem(USER_KEY, JSON.stringify(usuario));
+}
+
+export function clearSession(): void {
+  disconnectChatSocket();
+  localStorage.removeItem(TOKEN_KEY);
+  localStorage.removeItem(USER_KEY);
+  localStorage.removeItem("token");
+  localStorage.removeItem("admin_token");
+}
+
+export function getToken(): string | null {
+  return localStorage.getItem(TOKEN_KEY);
+}
+
+export function getStoredUser(): StoredUser | null {
+  const raw = localStorage.getItem(USER_KEY);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as StoredUser;
+  } catch {
+    return null;
+  }
+}

--- a/src/pages/Cadastro.tsx
+++ b/src/pages/Cadastro.tsx
@@ -1,14 +1,19 @@
 import { useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { Eye, EyeOff } from "lucide-react";
+import { toast } from "sonner";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import vectorWhiteLogo from "@/assets/vector-white-logo.png";
 import vectorHuman from "@/assets/vector-human.png";
+import { loginRequest, registerRequest } from "@/services/authApi";
+import { setSession } from "@/lib/authStorage";
 
 export function Cadastro() {
+  const navigate = useNavigate();
   const [currentStep, setCurrentStep] = useState(1);
   const [showPassword, setShowPassword] = useState(false);
+  const [loading, setLoading] = useState(false);
 
   const [formData, setFormData] = useState({
     nome: "",
@@ -58,14 +63,33 @@ export function Cadastro() {
     setCurrentStep(2);
   };
 
-  const handleRegister = (e: React.FormEvent) => {
+  const handleRegister = async (e: React.FormEvent) => {
     e.preventDefault();
-    const { email, senha } = formData;
+    const { nome, documento, celular, email, senha } = formData;
     if (!email.trim() || !senha.trim()) {
-      alert("Preencha e-mail e senha.");
+      toast.error("Preencha e-mail e senha.");
       return;
     }
-    console.log("Dados completos do cadastro:", formData);
+    const docDigits = documento.replace(/\D/g, "");
+    const celDigits = celular.replace(/\D/g, "");
+    setLoading(true);
+    try {
+      await registerRequest({
+        nome: nome.trim(),
+        email: email.trim(),
+        senha,
+        cpfCnpj: docDigits.length >= 11 ? docDigits : undefined,
+        celular: celDigits.length >= 10 ? celDigits : undefined,
+      });
+      const loginData = await loginRequest(email.trim(), senha);
+      setSession(loginData.tokenJWT, loginData.usuario);
+      toast.success("Conta criada. Bem-vindo!");
+      navigate("/cliente/inicio", { replace: true });
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Falha no cadastro");
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
@@ -126,6 +150,7 @@ export function Cadastro() {
                 <Button
                   type="button"
                   onClick={handleNextStep}
+                  disabled={loading}
                   className="w-full bg-[#3979A5] hover:bg-[#2f678d] text-white"
                 >
                   Continuar
@@ -175,9 +200,10 @@ export function Cadastro() {
 
                 <Button
                   type="submit"
+                  disabled={loading}
                   className="w-full bg-[#3979A5] hover:bg-[#2f678d] text-white"
                 >
-                  Cadastrar
+                  {loading ? "Cadastrando…" : "Cadastrar"}
                 </Button>
               </div>
             )}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,19 +1,38 @@
 import { useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { Eye, EyeOff } from "lucide-react";
+import { toast } from "sonner";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import vectorWhiteLogo from "@/assets/vector-white-logo.png";
 import vectorHuman from "@/assets/vector-human.png";
+import { loginRequest } from "@/services/authApi";
+import { setSession } from "@/lib/authStorage";
 
 export function Login() {
+  const navigate = useNavigate();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
+  const [loading, setLoading] = useState(false);
 
-  const handleLogin = (e: React.FormEvent) => {
+  const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
-    console.log("Payload de login:", { email, password });
+    setLoading(true);
+    try {
+      const data = await loginRequest(email, password);
+      setSession(data.tokenJWT, data.usuario);
+      toast.success(data.message);
+      if (data.usuario.nivel === "administrador") {
+        navigate("/admin/posts", { replace: true });
+      } else {
+        navigate("/cliente/inicio", { replace: true });
+      }
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Falha no login");
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
@@ -44,6 +63,7 @@ export function Login() {
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 required
+                disabled={loading}
               />
             </div>
 
@@ -63,6 +83,7 @@ export function Login() {
                   onChange={(e) => setPassword(e.target.value)}
                   required
                   className="pr-10"
+                  disabled={loading}
                 />
                 <button
                   type="button"
@@ -76,9 +97,10 @@ export function Login() {
 
             <Button
               type="submit"
+              disabled={loading}
               className="w-full bg-[#3979A5] hover:bg-[#2f678d] text-white"
             >
-              Entrar
+              {loading ? "Entrando…" : "Entrar"}
             </Button>
           </form>
 

--- a/src/services/authApi.ts
+++ b/src/services/authApi.ts
@@ -1,0 +1,56 @@
+const API_URL =
+  import.meta.env.VITE_API_URL?.trim() || "http://localhost:3000";
+
+export type AuthUser = {
+  id: number;
+  nome: string;
+  email: string;
+  nivel: string;
+};
+
+export type LoginResponse = {
+  message: string;
+  tokenJWT: string;
+  usuario: AuthUser;
+};
+
+async function readApiError(res: Response): Promise<string> {
+  const body = (await res.json().catch(() => ({}))) as {
+    message?: string | string[];
+  };
+  const m = body.message;
+  if (Array.isArray(m)) return m.join(", ");
+  if (typeof m === "string") return m;
+  return `Erro ${res.status}`;
+}
+
+export async function loginRequest(
+  email: string,
+  senha: string,
+): Promise<LoginResponse> {
+  const res = await fetch(`${API_URL}/usuario/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, senha }),
+  });
+  if (!res.ok) throw new Error(await readApiError(res));
+  return res.json() as Promise<LoginResponse>;
+}
+
+export type RegisterBody = {
+  nome: string;
+  email: string;
+  senha: string;
+  cpfCnpj?: string;
+  celular?: string;
+};
+
+export async function registerRequest(body: RegisterBody): Promise<unknown> {
+  const res = await fetch(`${API_URL}/usuario/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(await readApiError(res));
+  return res.json();
+}

--- a/src/services/socket.ts
+++ b/src/services/socket.ts
@@ -1,40 +1,42 @@
-import { io, Socket } from "socket.io-client";
+import { io, type Socket } from "socket.io-client";
 
-// URL base do seu servidor
-const SOCKET_URL = import.meta.env.VITE_SOCKET_URL || "https://despachante-bortone-release-production.up.railway.app";
+const SOCKET_URL =
+  import.meta.env.VITE_SOCKET_URL?.trim() ||
+  import.meta.env.VITE_API_URL?.trim() ||
+  "http://localhost:3000";
 
 let socket: Socket | null = null;
+let boundToken: string | null = null;
 
-export const connectChatSocket = (token: string) => {
-  if (socket) return socket;
+export function getChatSocket(token: string): Socket {
+  if (!token) throw new Error("Token ausente para o chat");
 
+  if (socket && boundToken !== token) {
+    socket.removeAllListeners();
+    socket.disconnect();
+    socket = null;
+    boundToken = null;
+  }
+
+  if (socket?.connected && boundToken === token) return socket;
+
+  boundToken = token;
   socket = io(SOCKET_URL, {
-    auth: {
-      token: token, // Aqui vai o JWT válido exigido pelo backend
-    },
-    transports: ["websocket"], // Força usar websocket ao invés de polling
-  });
-
-  socket.on("connect_error", (err) => {
-    console.error("Erro de conexão no Chat:", err.message);
-  });
-
-
-  socket.on("chat_error", (errorData) => {
-    // Aqui o vai tratar os erros que o dev mencionou:
-    // "Fora do horário comercial (8h as 18h)"
-    // "Limite de mensagens atingido (Spam)"
-    // "Mensagem maior que 200 caracteres"
-    console.warn("Erro de validação do chat:", errorData.message);
-    alert(errorData.message);
+    auth: { token },
+    transports: ["websocket"],
   });
 
   return socket;
-};
+}
 
-export const disconnectChatSocket = () => {
+export function disconnectChatSocket(): void {
   if (socket) {
+    socket.removeAllListeners();
     socket.disconnect();
     socket = null;
+    boundToken = null;
   }
-};
+}
+
+/** @deprecated use getChatSocket */
+export const connectChatSocket = getChatSocket;


### PR DESCRIPTION
o chat foi realmente integrado ao WebSocket do back-end (antes era só mock). Foi criado um fluxo básico de login/cadastro consumindo a API, salvando token e dados do usuário, e o chat passou a aparecer somente quando o usuário está logado (cliente no portal do cliente, admin no painel admin). O botão flutuante agora mostra notificações reais (mensagens não lidas) enquanto o chat está fechado, e o admin também vê contagem por sessão. Além disso, foi corrigido o problema visual dos balões: mensagens longas (uma palavra grande) agora quebram corretamente dentro do balão, sem estourar para fora. Também foi implementada a busca por nome no chat do admin de forma mais tolerante (sem travar por maiúsculas/minúsculas e acentos