### PR TITLE
feature: integração do FAQ e tela de duvidas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,6 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3599,7 +3598,6 @@
       "version": "24.12.0",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3608,7 +3606,6 @@
       "version": "19.2.14",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3617,7 +3614,6 @@
       "version": "19.2.3",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3667,7 +3663,6 @@
       "version": "8.57.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.1",
         "@typescript-eslint/types": "8.57.1",
@@ -3915,7 +3910,6 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4070,7 +4064,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4196,8 +4189,7 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -4382,8 +4374,7 @@
     },
     "node_modules/embla-carousel": {
       "version": "8.6.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -4508,7 +4499,6 @@
       "version": "9.39.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5001,8 +4991,7 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -5454,7 +5443,6 @@
     "node_modules/picomatch": {
       "version": "4.0.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5479,7 +5467,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5524,7 +5511,6 @@
     "node_modules/react": {
       "version": "19.2.4",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5554,7 +5540,6 @@
     "node_modules/react-dom": {
       "version": "19.2.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5584,7 +5569,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.74.0.tgz",
       "integrity": "sha512-yR6wHr99p9wFv686jhRWVSFhUvDvNbdUf2dKlbno8/VKOCuoNobDGC6S+M2dua9A9Yo8vpcrp8assIYbsZCQ9g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -5626,8 +5610,7 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-leaflet": {
       "version": "5.0.0",
@@ -5648,7 +5631,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -5821,8 +5803,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -6001,8 +5982,7 @@
     },
     "node_modules/tailwindcss": {
       "version": "4.2.1",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -6074,7 +6054,6 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6224,7 +6203,6 @@
     "node_modules/vite": {
       "version": "7.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -6366,7 +6344,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/components/admin/faq/CreateFaqCMS.tsx
+++ b/src/components/admin/faq/CreateFaqCMS.tsx
@@ -8,11 +8,8 @@ import { Textarea } from '@/components/ui/textarea';
 import { faqSchema, type FAQFormData } from './faq.schema';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { zodResolver } from '@hookform/resolvers/zod';
-import { FAQ_CATEGORIES_MOCK } from "@/mocks/faq.mocks"; 
 import type { FAQCategoryOption } from '@/types/faq.types';
 import { faqService } from '@/services/faqService';
-
-
 
 export default function NovoFAQ() {
   const navigate = useNavigate();
@@ -36,7 +33,7 @@ export default function NovoFAQ() {
   });
 
   useEffect(() => {
-    setCatOptions(FAQ_CATEGORIES_MOCK)
+    faqService.listarCategorias().then(setCatOptions);
   }, []);
 
   const onSubmit = async (data: FAQFormData) => {

--- a/src/components/admin/faq/EditarFaqCMS.tsx
+++ b/src/components/admin/faq/EditarFaqCMS.tsx
@@ -8,7 +8,6 @@ import { Textarea } from '@/components/ui/textarea';
 import { faqSchema, type FAQFormData } from './faq.schema';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { zodResolver } from '@hookform/resolvers/zod';
-import { FAQ_CATEGORIES_MOCK, FAQ_MOCK_DATA } from "@/mocks/faq.mocks"; 
 import type { FAQCategoryOption } from '@/types/faq.types';
 import { ConfirmDeleteModalFaq } from './ConfirmDeleteModal';
 import { toast } from 'sonner';
@@ -44,7 +43,7 @@ export default function EditarFAQ() {
 
   useEffect(() => {
     const carregarDados = async () => {
-      const options = FAQ_CATEGORIES_MOCK;
+      const options = await faqService.listarCategorias();
       setCatOptions(options);
 
       if (!id) return;
@@ -107,7 +106,6 @@ export default function EditarFAQ() {
       if(sucesso){
         navigate("/admin/faq");
       }
-      // Redireciona o usuário após a exclusão bem-sucedida
     } catch (erro) {
       toast.error("Erro ao excluir a pergunta.");
     } finally {

--- a/src/components/admin/faq/FaqAdmin.tsx
+++ b/src/components/admin/faq/FaqAdmin.tsx
@@ -6,7 +6,6 @@ import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import type { FAQItem, FAQStatus, FAQFilters, FAQCategoryOption, FAQStatusOption } from "@/types/faq.types";
-import { FAQ_MOCK_DATA, FAQ_CATEGORIES_MOCK, FAQ_STATUS_MOCK } from "@/mocks/faq.mocks";
 import { ConfirmDeleteModalFaq } from "./ConfirmDeleteModal";
 // import { id } from "date-fns/locale";
 import { faqService } from "@/services/faqService";
@@ -42,11 +41,17 @@ export default function FAQ() {
   const loadData = async () => {
     setLoading(true);
     try {
-      const dados = await faqService.listarTodos();
-      setFaqs(dados)
-      setCatOptions(FAQ_CATEGORIES_MOCK);
-      setStatusOptions(FAQ_STATUS_MOCK);
-
+      const [dados, categorias] = await Promise.all([
+        faqService.listarTodos(),
+        faqService.listarCategorias(),
+      ]);
+      setFaqs(dados);
+      setCatOptions(categorias);
+      setStatusOptions([
+        { value: "todas", label: "Status" },
+        { value: "Ativo", label: "Ativo" },
+        { value: "Inativo", label: "Inativo" },
+      ]);
     } catch (error) {
       console.error(error);
     } finally {

--- a/src/components/sections/FaqSection.tsx
+++ b/src/components/sections/FaqSection.tsx
@@ -1,26 +1,25 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { faqPublicoService } from '@/services/faqPublicoService';
+import type { FAQPublico } from '@/types/faqPublico.types';
 
 const FAQ = () => {
   const [openIndex, setOpenIndex] = useState<number | null>(null);
+  const [faqs, setFaqs] = useState<FAQPublico[]>([]);
+  const [loading, setLoading] = useState(true);
 
-  const faqs = [
-    {
-      pergunta: "Quais serviços um despachante oferece?",
-      resposta: "Um despachante atua como intermediário entre cidadãos/empresas e órgãos públicos, agilizando processos burocráticos. Oferecemos serviços como transferência de veículo, licenciamento anual, segunda via de documentos (CRLV, CRV), baixa de multas, vistoria veicular e muito mais."
-    },
-    {
-      pergunta: "Preciso ir ao Detran para resolver a documentação do meu veículo?",
-      resposta: "Não! Nós cuidamos de toda a documentação para você, sem precisar enfrentar filas ou se preocupar com burocracia. Você só precisa nos fornecer os documentos necessários."
-    },
-    {
-      pergunta: "Quanto tempo demora para concluir um serviço?",
-      resposta: "Os prazos variam: transferência (3 a 7 dias), licenciamento (1 a 3 dias), segunda via (2 a 5 dias). Sempre trabalhamos para agilizar ao máximo cada processo."
-    },
-    {
-      pergunta: "Quanto custa o serviço de despachante?",
-      resposta: "Os valores variam conforme o serviço. Entre em contato conosco para um orçamento personalizado e sem compromisso."
+  useEffect(() => {
+    async function loadFaqs() {
+      try {
+        const data = await faqPublicoService.listarTodos();
+        setFaqs(data);
+      } catch (error) {
+        console.error('Erro ao carregar FAQs:', error);
+      } finally {
+        setLoading(false);
+      }
     }
-  ];
+    loadFaqs();
+  }, []);
 
   const toggleFAQ = (index: number) => {
     setOpenIndex(openIndex === index ? null : index);
@@ -44,32 +43,42 @@ const FAQ = () => {
 
           {/* Coluna da direita - Lista de perguntas */}
           <div className="space-y-4">
-            {faqs.map((faq, index) => (
-              <div key={index} className="border border-gray-200 rounded-xl bg-white overflow-hidden">
-                <button
-                  onClick={() => toggleFAQ(index)}
-                  className="w-full flex justify-between items-center p-6 text-left hover:bg-gray-50 transition-colors"
-                >
-                  <span className="text-gray-800 font-medium pr-8">
-                    {index + 1}. {faq.pergunta}
-                  </span>
-                  <span className="text-2xl text-gray-500 flex-shrink-0">
-                    {openIndex === index ? '−' : '+'}
-                  </span>
-                </button>
-                
-                {openIndex === index && (
-                  <div className="px-6 pb-6 text-gray-600 border-t border-gray-100 pt-4">
-                    {faq.resposta}
-                  </div>
-                )}
+            {loading ? (
+              <div className="flex items-center justify-center h-24 text-gray-500">
+                Carregando...
               </div>
-            ))}
+            ) : faqs.length === 0 ? (
+              <div className="flex items-center justify-center h-24 text-gray-500">
+                Nenhuma dúvida disponível no momento.
+              </div>
+            ) : (
+              faqs.map((faq, index) => (
+                <div key={faq.id} className="border border-gray-200 rounded-xl bg-white overflow-hidden">
+                  <button
+                    onClick={() => toggleFAQ(index)}
+                    className="w-full flex justify-between items-center p-6 text-left hover:bg-gray-50 transition-colors"
+                  >
+                    <span className="text-gray-800 font-medium pr-8">
+                      {index + 1}. {faq.pergunta}
+                    </span>
+                    <span className="text-2xl text-gray-500 flex-shrink-0">
+                      {openIndex === index ? '−' : '+'}
+                    </span>
+                  </button>
+                  
+                  {openIndex === index && (
+                    <div className="px-6 pb-6 text-gray-600 border-t border-gray-100 pt-4">
+                      {faq.resposta}
+                    </div>
+                  )}
+                </div>
+              ))
+            )}
 
             {/* Botão Veja mais dúvidas - CENTRALIZADO */}
             <div className="mt-8 flex justify-center">
               <a 
-                href="#" 
+                href="/duvidas" 
                 className="bg-primary inline-flex items-center gap-2 text-white font-medium px-8 py-4 rounded-full transition-colors hover:opacity-90"
               >
                 <span>Veja mais dúvidas</span>

--- a/src/services/faqPublicoService.ts
+++ b/src/services/faqPublicoService.ts
@@ -1,9 +1,40 @@
 import type { FAQPublico } from "@/types/faqPublico.types";
-import { FAQ_PUBLICO_MOCK } from "@/mocks/faqPublico.mocks";
 
 const API_URL = import.meta.env.VITE_API_URL || "https://despachante-bortone-release-production.up.railway.app";
 
-let faqs = [...FAQ_PUBLICO_MOCK];
+const CATEGORIA_LABEL: Record<string, string> = {
+  documentacao: "Documentação",
+  regularizacao: "Regularização",
+  manutencao: "Manutenção",
+  outros: "Outros",
+  frequentes: "Frequentes",
+};
+
+interface FaqApiResponse {
+  id: number;
+  pergunta: string;
+  resposta: string;
+  categoria: string;
+  status: boolean;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+function mapApiToFaqPublico(api: FaqApiResponse): FAQPublico {
+  return {
+    id: `#${api.id}`,
+    pergunta: api.pergunta,
+    resposta: api.resposta,
+    categoria: CATEGORIA_LABEL[api.categoria] ?? api.categoria,
+    status: api.status ? "Ativo" : "Inativo",
+    dataCriacao: api.createdAt
+      ? new Date(api.createdAt).toLocaleDateString("pt-BR")
+      : "—",
+    dataAtualizacao: api.updatedAt
+      ? new Date(api.updatedAt).toLocaleDateString("pt-BR")
+      : "—",
+  };
+}
 
 const handleResponse = async (response: Response) => {
   if (!response.ok) {
@@ -15,19 +46,12 @@ const handleResponse = async (response: Response) => {
 export const faqPublicoService = {
   async listarTodos(): Promise<FAQPublico[]> {
     try {
-      // 🔥 quando tiver API:
-      // const response = await fetch(`${API_URL}/faq`);
-      // const data = await handleResponse(response);
-
-      // mock
-      await new Promise((resolve) => setTimeout(resolve, 500));
-
-      // 🔥 REGRA DA ISSUE
-      return faqs.filter((faq) => faq.status === "Ativo");
-
+      const response = await fetch(`${API_URL}/faq`);
+      const data: FaqApiResponse[] = await handleResponse(response);
+      return data.map(mapApiToFaqPublico);
     } catch (erro) {
       console.error("Erro ao listar FAQ público:", erro);
       return [];
     }
-  }
+  },
 };

--- a/src/services/faqService.ts
+++ b/src/services/faqService.ts
@@ -1,13 +1,53 @@
-import type { FAQItem, FAQStatus } from "@/types/faq.types";
-import { FAQ_MOCK_DATA } from "@/mocks/faq.mocks"; // Ajuste o caminho conforme sua estrutura
+import type { FAQItem, FAQCategoryOption } from "@/types/faq.types";
 
 const API_URL = import.meta.env.VITE_API_URL || "https://despachante-bortone-release-production.up.railway.app";
 
-let faqs = [...FAQ_MOCK_DATA];
+const CATEGORIA_LABEL: Record<string, string> = {
+  documentacao: "Documentação",
+  regularizacao: "Regularização",
+  manutencao: "Manutenção",
+  outros: "Outros",
+  frequentes: "Frequentes",
+};
+
+const CATEGORIA_ENUM: Record<string, string> = Object.fromEntries(
+  Object.entries(CATEGORIA_LABEL).map(([key, val]) => [val, key])
+);
+
+interface FaqApiResponse {
+  id: number;
+  pergunta: string;
+  resposta: string;
+  categoria: string;
+  status: boolean;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+function mapApiToFaqItem(api: FaqApiResponse): FAQItem {
+  return {
+    id: `#${api.id}`,
+    pergunta: api.pergunta,
+    resposta: api.resposta,
+    categoria: CATEGORIA_LABEL[api.categoria] ?? api.categoria,
+    status: api.status ? "Ativo" : "Inativo",
+    dataCriacao: api.createdAt
+      ? new Date(api.createdAt).toLocaleDateString("pt-BR")
+      : "—",
+    dataAtualizacao: api.updatedAt
+      ? new Date(api.updatedAt).toLocaleDateString("pt-BR")
+      : "—",
+  };
+}
+
+function cleanId(id: string): string {
+  return id.replace("#", "");
+}
 
 const handleResponse = async (response: Response) => {
   if (!response.ok) {
-    throw new Error(`Erro: ${response.status}`);
+    const body = await response.text().catch(() => "");
+    throw new Error(`Erro ${response.status}: ${body}`);
   }
   return response.json();
 };
@@ -16,54 +56,50 @@ export const faqService = {
   // GET: Listar todas as perguntas
   listarTodos: async (): Promise<FAQItem[]> => {
     try {
-      // Quando a API estiver pronta, basta descomentar as linhas abaixo:
-      // const response = await fetch(`${API_URL}/faq`);
-      // return await handleResponse(response);
-      return new Promise((resolve) => {
-        setTimeout(() => resolve(faqs), 500);
-      });
+      const response = await fetch(`${API_URL}/faq/admin`);
+      const data: FaqApiResponse[] = await handleResponse(response);
+      return data.map(mapApiToFaqItem);
     } catch (erro) {
-      console.error('Erro ao listar FAQ:', erro);
+      console.error("Erro ao listar FAQ:", erro);
       return [];
     }
   },
 
   // GET: Buscar por ID
   buscarPorId: async (id: string): Promise<FAQItem | null> => {
-  try {
-
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    const idLimpoParaBusca = id.replace("#", "");
-
-    const item = faqs.find((f) => {
-      const idMockLimpo = f.id.toString().replace("#", "");
-      return idMockLimpo === idLimpoParaBusca;
-    });
-
-    return item || null;
-  } catch (erro) {
-    console.error('Erro ao buscar FAQ:', erro);
-    return null;
-  }
-},
+    try {
+      const numericId = cleanId(id);
+      const response = await fetch(`${API_URL}/faq/${numericId}`);
+      const data: FaqApiResponse = await handleResponse(response);
+      return mapApiToFaqItem(data);
+    } catch (erro) {
+      console.error("Erro ao buscar FAQ:", erro);
+      return null;
+    }
+  },
 
   // POST: Criar nova pergunta
   criar: async (
-    data: Omit<FAQItem, 'id' | 'dataCriacao' | 'dataAtualizacao'>
+    data: Omit<FAQItem, "id" | "dataCriacao" | "dataAtualizacao">
   ): Promise<boolean> => {
     try {
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-      const novoItem: FAQItem = {
-        ...data,
-        id: `#${Math.floor(Math.random() * 1000).toString().padStart(3, '0')}`,
-        dataCriacao: new Date().toLocaleDateString('pt-BR'),
-        dataAtualizacao: new Date().toLocaleDateString('pt-BR'),
+      const payload = {
+        pergunta: data.pergunta,
+        resposta: data.resposta,
+        categoria: CATEGORIA_ENUM[data.categoria] ?? data.categoria.toLowerCase(),
+        status: data.status === "Ativo",
       };
-      
-      faqs.unshift(novoItem); // Adiciona no início da lista
+
+      const response = await fetch(`${API_URL}/faq/admin`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      await handleResponse(response);
       return true;
     } catch (erro) {
-      console.error('Erro ao criar FAQ:', erro);
+      console.error("Erro ao criar FAQ:", erro);
       return false;
     }
   },
@@ -71,49 +107,59 @@ export const faqService = {
   // PUT/PATCH: Atualizar pergunta existente
   atualizar: async (id: string, dados: Partial<FAQItem>): Promise<boolean> => {
     try {
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+      const numericId = cleanId(id);
 
-        const idParamLimpo = id.replace("#", "");
+      const payload: Record<string, unknown> = {};
+      if (dados.pergunta !== undefined) payload.pergunta = dados.pergunta;
+      if (dados.resposta !== undefined) payload.resposta = dados.resposta;
+      if (dados.categoria !== undefined)
+        payload.categoria = CATEGORIA_ENUM[dados.categoria] ?? dados.categoria.toLowerCase();
+      if (dados.status !== undefined)
+        payload.status = dados.status === "Ativo";
 
-        const index = faqs.findIndex((f) => {
-        const idMockLimpo = f.id.toString().replace("#", "");
-        return idMockLimpo === idParamLimpo;
-        });
+      const response = await fetch(`${API_URL}/faq/admin/${numericId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
 
-        if (index === -1) {
-        console.warn(`FAQ com id ${id} não encontrado para atualização.`);
-        return false;
-        }
-
-        faqs[index] = {
-        ...faqs[index],
-        ...dados,
-        dataAtualizacao: new Date().toLocaleDateString('pt-BR'),
-        };
-    
-        return true; 
+      await handleResponse(response);
+      return true;
     } catch (erro) {
-        console.error('Erro ao atualizar FAQ:', erro);
-        return false;
-        }
+      console.error("Erro ao atualizar FAQ:", erro);
+      return false;
+    }
   },
 
   // DELETE: Remover pergunta
   excluir: async (id: string): Promise<boolean> => {
-  try {
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-    
-    const idParaRemover = id.replace("#", "");
-    
-    faqs = faqs.filter((f) => {
-      const idMockLimpo = f.id.toString().replace("#", "");
-      return idMockLimpo !== idParaRemover;
-    });
-    
-    return true;
-  } catch (erro) {
-    console.error('Erro ao excluir FAQ:', erro);
-    return false;
-  }
-  }
-}
+    try {
+      const numericId = cleanId(id);
+
+      const response = await fetch(`${API_URL}/faq/admin/${numericId}`, {
+        method: "DELETE",
+      });
+
+      await handleResponse(response);
+      return true;
+    } catch (erro) {
+      console.error("Erro ao excluir FAQ:", erro);
+      return false;
+    }
+  },
+
+  // GET: Listar categorias da API
+  listarCategorias: async (): Promise<FAQCategoryOption[]> => {
+    try {
+      const response = await fetch(`${API_URL}/faq/categorias`);
+      const categorias: string[] = await handleResponse(response);
+      return categorias.map((cat) => ({
+        value: CATEGORIA_LABEL[cat] ?? cat,
+        label: CATEGORIA_LABEL[cat] ?? cat,
+      }));
+    } catch (erro) {
+      console.error("Erro ao listar categorias:", erro);
+      return [];
+    }
+  },
+};


### PR DESCRIPTION
Realizada a integração da API do FAQ com o frontend. A integração foi feita com base na branch release/entrega-04-05 do back-end

**Alterações feitas**

**1- faq.service**

Antes estava com array local com setTimeout, agora faz as chamadas HTTP reais:
- listarTodos() (GET /faq/admin)
- buscarPorId(id) (GET /faq/:id)
- criar(data) (POST /faq/admin)
- atualizar(id, dados) (PATCH /faq/admin/:id)
- excluir(id) (DELETE /faq/admin/:id)
- listarCategorias() (GET /faq/categorias)

Inclui funções de mapeamento bidirecional entre formatos:
- status: boolean (API) ↔ "Ativo" | "Inativo" (front)
- categoria: "documentacao" (API enum) ↔ "Documentação" (front label)

**2- faqPublicoService.ts**

Antes usava FAQ_PUBLICO_MOCK, agora consome o GET /faq (que já filtra status: true no back-end)

**3- faqAdmin.tsx**

Removido import de FAQ_MOCK_DATA, FAQ_CATEGORIES_MOCK, FAQ_STATUS_MOCK. O useEffect agora carrega FAQs e categorias da API em paralelo via Promise.all

**4- createFaqCMS.tsx**

Removido import de FAQ_CATEGORIES_MOCK. O useEffect agora busca categorias via faqService.listarCategorias()

**5- editarFaqCMS.tsx**

Removido import de FAQ_CATEGORIES_MOCK e FAQ_MOCK_DATA. Agora as categorias são carregadas via API

**6- faqSection.tsx**

Removido array faqs hardcoded. Adicionei o Adicionado useEffect que consome faqPublicoService.listarTodos(), foi adicionado também Adicionados estados de loading e empty.
